### PR TITLE
feat: add partition_info field in system.public.tables

### DIFF
--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -18,6 +18,20 @@ Table,Create Table,
 String("partition_table_t"),String("CREATE TABLE `partition_table_t` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) PARTITION BY KEY(name) PARTITIONS 4 ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
 
 
+SELECT * from system.public.tables where table_name like "%partition_table_t%" order by table_id;
+
+timestamp,catalog,schema,table_name,table_id,engine,partition_info,
+Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(42),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_1"),UInt64(44),String("Analytic"),String(""),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_2"),UInt64(46),String("Analytic"),String(""),
+
+
+SELECT * from system.public.tables where partition_info is not null;
+
+timestamp,catalog,schema,table_name,table_id,engine,partition_info,
+Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(42),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
+
+
 INSERT INTO partition_table_t (t, name, value)
 VALUES (1651737067000, "ceresdb0", 100),
        (1651737067000, "ceresdb1", 101),

--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -21,15 +21,17 @@ String("partition_table_t"),String("CREATE TABLE `partition_table_t` (`tsid` uin
 SELECT * from system.public.tables where table_name like "%partition_table_t%" order by table_id;
 
 timestamp,catalog,schema,table_name,table_id,engine,partition_info,
-Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(42),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
-Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_1"),UInt64(44),String("Analytic"),String(""),
-Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_2"),UInt64(46),String("Analytic"),String(""),
+Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(43),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_0"),UInt64(44),String("Analytic"),String(""),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_1"),UInt64(45),String("Analytic"),String(""),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_3"),UInt64(46),String("Analytic"),String(""),
+Timestamp(0),String("ceresdb"),String("public"),String("__partition_table_t_2"),UInt64(47),String("Analytic"),String(""),
 
 
 SELECT * from system.public.tables where partition_info is not null;
 
 timestamp,catalog,schema,table_name,table_id,engine,partition_info,
-Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(42),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
+Timestamp(0),String("ceresdb"),String("public"),String("partition_table_t"),UInt64(43),String("Analytic"),String("PARTITION BY KEY(name) PARTITIONS 4"),
 
 
 INSERT INTO partition_table_t (t, name, value)

--- a/integration_tests/cases/env/cluster/ddl/partition_table.sql
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.sql
@@ -10,6 +10,10 @@ CREATE TABLE `partition_table_t`(
 
 SHOW CREATE TABLE partition_table_t;
 
+SELECT * from system.public.tables where table_name like "%partition_table_t%" order by table_id;
+
+SELECT * from system.public.tables where partition_info is not null;
+
 INSERT INTO partition_table_t (t, name, value)
 VALUES (1651737067000, "ceresdb0", 100),
        (1651737067000, "ceresdb1", 101),


### PR DESCRIPTION
## Rationale
The system table `tables` adds a `partition_info` column to distinguish whether the table is a partition table.

## Detailed Changes
Add `partition_info` in `system.public.tables`.

## Test Plan
Add a test in integration-test.