### PR TITLE
feat: support OSS in memory multipart upload 

### DIFF
--- a/src/analytic_engine/src/sst/parquet/writer.rs
+++ b/src/analytic_engine/src/sst/parquet/writer.rs
@@ -27,7 +27,7 @@ use common_types::{
 use datafusion::parquet::basic::Compression;
 use futures::StreamExt;
 use generic_error::BoxError;
-use logger::{debug, error};
+use logger::{debug, error, info};
 use object_store::{ObjectStoreRef, Path};
 use parquet::data_type::AsBytes;
 use snafu::{OptionExt, ResultExt};
@@ -508,6 +508,7 @@ impl<'a> SstWriter for ParquetSstWriter<'a> {
 
         let (meta_aborter, meta_sink) =
             ObjectStoreMultiUploadAborter::initialize_upload(self.store, &meta_path).await?;
+        info!("meta data begin write");
         let meta_size = match write_metadata(meta_sink, parquet_metadata, &meta_path).await {
             Ok(v) => v,
             Err(e) => {
@@ -516,6 +517,7 @@ impl<'a> SstWriter for ParquetSstWriter<'a> {
                 return Err(e);
             }
         };
+        info!("meta data finish write");
 
         data_encoder
             .set_meta_data_size(meta_size)
@@ -619,7 +621,6 @@ impl<'a> ColumnEncodingSampler<'a> {
 
 #[cfg(test)]
 mod tests {
-
     use std::{sync::Arc, task::Poll};
 
     use bytes_ext::Bytes;

--- a/src/components/object_store/src/aliyun.rs
+++ b/src/components/object_store/src/aliyun.rs
@@ -62,6 +62,7 @@ pub fn try_new(aliyun_opts: &AliyunOptions) -> upstream::Result<AmazonS3> {
         .with_endpoint(endpoint)
         .with_bucket_name(bucket)
         .with_client_options(cli_opt)
+        .with_proxy_url(&aliyun_opts.proxy)
         .with_retry(retry_config)
         .build()
 }

--- a/src/components/object_store/src/config.rs
+++ b/src/components/object_store/src/config.rs
@@ -77,6 +77,7 @@ pub struct AliyunOptions {
     pub key_id: String,
     pub key_secret: String,
     pub endpoint: String,
+    pub proxy: String,
     pub bucket: String,
     pub prefix: String,
     #[serde(default)]

--- a/src/components/object_store/src/config.rs
+++ b/src/components/object_store/src/config.rs
@@ -83,6 +83,7 @@ pub struct AliyunOptions {
     pub http: HttpOptions,
     #[serde(default)]
     pub retry: RetryOptions,
+    pub enable_multipart: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/object_store/src/in_memory_multipart.rs
+++ b/src/components/object_store/src/in_memory_multipart.rs
@@ -1,0 +1,164 @@
+use std::{
+    fmt::{Display, Formatter},
+    future::Future,
+    io,
+    ops::Range,
+    pin::Pin,
+    sync::Arc,
+    task::Poll,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{future::ok, stream::BoxStream};
+use logger::{error, info};
+use tokio::io::AsyncWrite;
+use upstream::{path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore};
+use uuid::Uuid;
+
+use crate::ObjectStoreRef;
+
+/// Wrap a real store and save data in memory before flush to
+/// the target location.
+#[derive(Debug)]
+pub struct StoreInMemory {
+    enable: bool,
+    store: ObjectStoreRef,
+}
+
+impl Display for StoreInMemory {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl StoreInMemory {
+    pub fn new(enable: bool, store: ObjectStoreRef) -> Self {
+        Self { enable, store }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for StoreInMemory {
+    async fn put(&self, location: &Path, bytes: Bytes) -> upstream::Result<()> {
+        info!("object store begin put");
+        let result = self.store.put(location, bytes).await;
+        info!("object store end put");
+        return result;
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> upstream::Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        if !self.enable {
+            return self.store.put_multipart(location).await;
+        }
+        let upload_id = Uuid::new_v4().to_string();
+        let upload = InMemoryUpload {
+            location: location.clone(),
+            data: Vec::new(),
+            storage: self.store.clone(),
+            completion_task: None,
+        };
+        Ok((upload_id, Box::new(upload)))
+    }
+
+    async fn abort_multipart(
+        &self,
+        location: &Path,
+        multipart_id: &MultipartId,
+    ) -> upstream::Result<()> {
+        // Do nothing
+        Ok(())
+    }
+
+    async fn get(&self, location: &Path) -> upstream::Result<GetResult> {
+        self.store.get(location).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> upstream::Result<Bytes> {
+        self.store.get_range(location, range).await
+    }
+
+    async fn head(&self, location: &Path) -> upstream::Result<ObjectMeta> {
+        self.store.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> upstream::Result<()> {
+        self.store.delete(location).await
+    }
+
+    async fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> upstream::Result<BoxStream<'_, upstream::Result<ObjectMeta>>> {
+        self.store.list(prefix).await
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> upstream::Result<ListResult> {
+        self.store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> upstream::Result<()> {
+        self.store.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> upstream::Result<()> {
+        self.store.copy_if_not_exists(from, to).await
+    }
+}
+
+type BoxedTryFuture<T> = Pin<Box<dyn Future<Output = upstream::Result<T, io::Error>> + Send>>;
+
+struct InMemoryUpload {
+    location: Path,
+    data: Vec<u8>,
+    storage: ObjectStoreRef,
+    completion_task: Option<BoxedTryFuture<()>>,
+}
+
+impl AsyncWrite for InMemoryUpload {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<upstream::Result<usize, io::Error>> {
+        self.data.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<upstream::Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<upstream::Result<(), io::Error>> {
+        let data = Bytes::from(std::mem::take(&mut self.data));
+
+        let inner = Arc::clone(&self.storage);
+        let location = self.location.clone();
+
+        let completion_task = self.completion_task.get_or_insert_with(|| {
+            Box::pin(async move {
+                info!("Flushing data to object store: {:?}", location);
+                match inner.put(&location, data).await {
+                    Ok(_) => {
+                        info!("Successfully put object: {:?}", location);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        error!("Failed to put object: {:?}", e);
+                        Err(io::Error::new(io::ErrorKind::Other, e))
+                    }
+                }
+            })
+        });
+        Pin::new(completion_task).poll(cx)
+    }
+}

--- a/src/components/object_store/src/lib.rs
+++ b/src/components/object_store/src/lib.rs
@@ -27,6 +27,7 @@ pub use upstream::{
 pub mod aliyun;
 pub mod config;
 pub mod disk_cache;
+pub mod in_memory_multipart;
 pub mod mem_cache;
 pub mod metrics;
 pub mod multipart;


### PR DESCRIPTION
## Rationale
In some object storage and test scenarios, the support for the multi upload function is incomplete, and we need to directly use put to replace it.

## Detailed Changes
* Support OSS in memory multipart upload, it will batch the data in memory and upload it.
* Fix proxy config, setting proxy before will not take effect.

## Test Plan
paas CI.