### PR TITLE
chore: log more info for debug when tables with same name found

### DIFF
--- a/src/analytic_engine/src/table/data.rs
+++ b/src/analytic_engine/src/table/data.rs
@@ -796,6 +796,15 @@ impl TableDataSet {
     pub fn insert_if_absent(&mut self, table_data_ref: TableDataRef) -> bool {
         let table_name = &table_data_ref.name;
         if self.table_datas.contains_key(table_name) {
+            let exist_table = self.table_datas.get(table_name).unwrap();
+            logger::error!(
+                "found duplicated table_name:{}, exist_table_id:{}, exist_table_shard_id:{}, inserted_table_id:{}, inserted_table_shard_id:{}",
+                table_name,
+                exist_table.id,
+                exist_table.shard_info.shard_id,
+                table_data_ref.id,
+                table_data_ref.shard_info.shard_id,
+            );
             return false;
         }
         self.table_datas


### PR DESCRIPTION
## Rationale
We just panic but log nothing when found two tables with the same table name, it turns debugging into a disaster...

## Detailed Changes
Log the needed table infos when found two tables with the same table name before panic.

## Test Plan
Test maually.
