### PR TITLE
refactor: partitioned_lock's elaboration

### DIFF
--- a/src/components/object_store/src/disk_cache.rs
+++ b/src/components/object_store/src/disk_cache.rs
@@ -296,7 +296,7 @@ impl DiskCache {
 
         Ok(Self {
             root_dir,
-            meta_cache: Arc::new(PartitionedMutex::try_new_bit_len(
+            meta_cache: Arc::new(PartitionedMutex::try_new_with_bit_len(
                 init_lru,
                 partition_bits,
                 SeaHasherBuilder {},
@@ -545,7 +545,7 @@ impl DiskCacheStore {
             assert!(cap_per_part > 0);
             Ok(LruCache::new(cap_per_part))
         };
-        let meta_cache = PartitionedMutex::try_new_bit_len(
+        let meta_cache = PartitionedMutex::try_new_with_bit_len(
             init_size_lru,
             FILE_SIZE_CACHE_PARTITION_BITS,
             SeaHasherBuilder,

--- a/src/components/object_store/src/disk_cache.rs
+++ b/src/components/object_store/src/disk_cache.rs
@@ -296,7 +296,7 @@ impl DiskCache {
 
         Ok(Self {
             root_dir,
-            meta_cache: Arc::new(PartitionedMutex::try_new(
+            meta_cache: Arc::new(PartitionedMutex::try_new_bit_len(
                 init_lru,
                 partition_bits,
                 SeaHasherBuilder {},
@@ -545,7 +545,7 @@ impl DiskCacheStore {
             assert!(cap_per_part > 0);
             Ok(LruCache::new(cap_per_part))
         };
-        let meta_cache = PartitionedMutex::try_new(
+        let meta_cache = PartitionedMutex::try_new_bit_len(
             init_size_lru,
             FILE_SIZE_CACHE_PARTITION_BITS,
             SeaHasherBuilder,

--- a/src/components/object_store/src/mem_cache.rs
+++ b/src/components/object_store/src/mem_cache.rs
@@ -81,7 +81,7 @@ impl MemCache {
             ))
         };
 
-        let inner = PartitionedMutex::try_new_bit_len(
+        let inner = PartitionedMutex::try_new_with_bit_len(
             init_lru,
             partition_bits,
             build_fixed_seed_ahasher_builder(),

--- a/src/components/object_store/src/mem_cache.rs
+++ b/src/components/object_store/src/mem_cache.rs
@@ -81,7 +81,7 @@ impl MemCache {
             ))
         };
 
-        let inner = PartitionedMutex::try_new(
+        let inner = PartitionedMutex::try_new_bit_len(
             init_lru,
             partition_bits,
             build_fixed_seed_ahasher_builder(),

--- a/src/components/partitioned_lock/src/lib.rs
+++ b/src/components/partitioned_lock/src/lib.rs
@@ -36,8 +36,7 @@ impl<T, B> PartitionedRwLock<T, B>
 where
     B: BuildHasher,
 {
-    /// the old way to new a partitioned lock, retained for Compatibility
-    /// the capactity of partition is 2^partition_bit_Len
+    /// New cache with capacity set to `2^bit_len`
     pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
@@ -47,12 +46,10 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
-        PartitionedRwLock::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedRwLock::try_new(init_fn, partition_num, hash_builder)
     }
 
-    /// the suggested method of new a partitioned lock
-    /// the capactity is the next power of 2 of suggest_cap
-    /// example: suggest_cap = 10, partition_num = 16
+    /// New cache with capacity round to `suggest_cap`'s power of 2
     pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
@@ -62,7 +59,7 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = suggest_cap.next_power_of_two();
-        PartitionedRwLock::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedRwLock::try_new(init_fn, partition_num, hash_builder)
     }
 
     pub fn read<K: Eq + Hash>(&self, key: &K) -> RwLockReadGuard<'_, T> {
@@ -82,11 +79,7 @@ where
     }
 
     #[inline]
-    fn try_new_with_partition_num<F, E>(
-        init_fn: F,
-        partition_num: usize,
-        hash_builder: B,
-    ) -> Result<Self, E>
+    fn try_new<F, E>(init_fn: F, partition_num: usize, hash_builder: B) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
     {
@@ -122,8 +115,7 @@ impl<T, B> PartitionedMutex<T, B>
 where
     B: BuildHasher,
 {
-    /// the old way to new a partitioned lock, retained for Compatibility
-    /// the capactity of partition is 2^partition_bit_Len
+    /// New cache with capacity set to `2^bit_len`
     pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
@@ -133,12 +125,10 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
-        PartitionedMutex::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedMutex::try_new(init_fn, partition_num, hash_builder)
     }
 
-    /// the suggested method of new a partitioned lock
-    /// the capactity is the next power of 2 of suggest_cap
-    /// example: suggest_cap = 10, partition _num = 16
+    /// New cache with capacity round to `suggest_cap`'s power of 2
     pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
@@ -148,7 +138,7 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = suggest_cap.next_power_of_two();
-        PartitionedMutex::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedMutex::try_new(init_fn, partition_num, hash_builder)
     }
 
     pub fn lock<K: Eq + Hash>(&self, key: &K) -> MutexGuard<'_, T> {
@@ -162,11 +152,7 @@ where
     }
 
     #[inline]
-    fn try_new_with_partition_num<F, E>(
-        init_fn: F,
-        partition_num: usize,
-        hash_builder: B,
-    ) -> Result<Self, E>
+    fn try_new<F, E>(init_fn: F, partition_num: usize, hash_builder: B) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
     {
@@ -206,8 +192,7 @@ impl<T, B> PartitionedMutexAsync<T, B>
 where
     B: BuildHasher,
 {
-    /// the old way to new a partitioned lock, retained for Compatibility
-    /// the capactity of partition is 2^partition_bit_Len
+    /// New cache with capacity set to `2^bit_len`
     pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
@@ -217,12 +202,10 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
-        PartitionedMutexAsync::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedMutexAsync::try_new(init_fn, partition_num, hash_builder)
     }
 
-    /// the suggested method of new a partitioned lock
-    /// the capactity is the next power of 2 of suggest _Cap
-    /// example: suggest_cap = 10, partition _num = 16
+    /// New cache with capacity round to `suggest_cap`'s power of 2
     pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
@@ -232,7 +215,7 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = suggest_cap.next_power_of_two();
-        PartitionedMutexAsync::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+        PartitionedMutexAsync::try_new(init_fn, partition_num, hash_builder)
     }
 
     pub async fn lock<K: Eq + Hash>(&self, key: &K) -> tokio::sync::MutexGuard<'_, T> {
@@ -242,11 +225,7 @@ where
     }
 
     #[inline]
-    fn try_new_with_partition_num<F, E>(
-        init_fn: F,
-        partition_num: usize,
-        hash_builder: B,
-    ) -> Result<Self, E>
+    fn try_new<F, E>(init_fn: F, partition_num: usize, hash_builder: B) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
     {

--- a/src/components/partitioned_lock/src/lib.rs
+++ b/src/components/partitioned_lock/src/lib.rs
@@ -46,7 +46,7 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
-        PartitionedRwLock::try_new_with_partition_num(init_fn, hash_builder, partition_num)
+        PartitionedRwLock::try_new_with_partition_num(init_fn, partition_num, hash_builder)
     }
 
     /// the suggested method of new a partitioned lock
@@ -59,7 +59,7 @@ where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = suggest_cap.next_power_of_two();
-        PartitionedRwLock::try_new_with_partition_num(init_fn, hash_builder, partition_num)
+        PartitionedRwLock::try_new_with_partition_num(init_fn, partition_num, hash_builder)
     }
 
     pub fn read<K: Eq + Hash>(&self, key: &K) -> RwLockReadGuard<'_, T> {
@@ -81,8 +81,8 @@ where
     #[inline]
     fn try_new_with_partition_num<F, E>(
         init_fn: F,
-        hash_builder: B,
         partition_num: usize,
+        hash_builder: B,
     ) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
@@ -119,20 +119,28 @@ impl<T, B> PartitionedMutex<T, B>
 where
     B: BuildHasher,
 {
-    pub fn try_new<F, E>(init_fn: F, partition_bit_len: usize, hash_builder: B) -> Result<Self, E>
+    pub fn try_new_bit_len<F, E>(
+        init_fn: F,
+        partition_bit_len: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
-        let partitions = (0..partition_num)
-            .map(|_| init_fn(partition_num).map(Mutex::new))
-            .collect::<Result<Vec<Mutex<T>>, E>>()?;
+        PartitionedMutex::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+    }
 
-        Ok(Self {
-            partitions,
-            partition_mask: partition_num - 1,
-            hash_builder,
-        })
+    pub fn try_new_suggest_cap<F, E>(
+        init_fn: F,
+        suggest_cap: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
+    where
+        F: Fn(usize) -> Result<T, E>,
+    {
+        let partition_num = suggest_cap.next_power_of_two();
+        PartitionedMutex::try_new_with_partition_num(init_fn, partition_num, hash_builder)
     }
 
     pub fn lock<K: Eq + Hash>(&self, key: &K) -> MutexGuard<'_, T> {
@@ -143,6 +151,26 @@ where
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &Mutex<T> {
         &self.partitions[(self.hash_builder.hash_one(key) as usize) & self.partition_mask]
+    }
+
+    #[inline]
+    fn try_new_with_partition_num<F, E>(
+        init_fn: F,
+        partition_num: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
+    where
+        F: Fn(usize) -> Result<T, E>,
+    {
+        let partitions = (0..partition_num)
+            .map(|_| init_fn(partition_num).map(Mutex::new))
+            .collect::<Result<Vec<Mutex<T>>, E>>()?;
+
+        Ok(Self {
+            partitions,
+            partition_mask: partition_num - 1,
+            hash_builder,
+        })
     }
 
     #[cfg(test)]
@@ -170,11 +198,45 @@ impl<T, B> PartitionedMutexAsync<T, B>
 where
     B: BuildHasher,
 {
-    pub fn try_new<F, E>(init_fn: F, partition_bit_len: usize, hash_builder: B) -> Result<Self, E>
+    pub fn try_new_bit_len<F, E>(
+        init_fn: F,
+        partition_bit_len: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
     where
         F: Fn(usize) -> Result<T, E>,
     {
         let partition_num = 1 << partition_bit_len;
+        PartitionedMutexAsync::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+    }
+
+    pub fn try_new_suggest_cap<F, E>(
+        init_fn: F,
+        suggest_cap: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
+    where
+        F: Fn(usize) -> Result<T, E>,
+    {
+        let partition_num = suggest_cap.next_power_of_two();
+        PartitionedMutexAsync::try_new_with_partition_num(init_fn, partition_num, hash_builder)
+    }
+
+    pub async fn lock<K: Eq + Hash>(&self, key: &K) -> tokio::sync::MutexGuard<'_, T> {
+        let mutex = self.get_partition(key);
+
+        mutex.lock().await
+    }
+
+    #[inline]
+    fn try_new_with_partition_num<F, E>(
+        init_fn: F,
+        partition_num: usize,
+        hash_builder: B,
+    ) -> Result<Self, E>
+    where
+        F: Fn(usize) -> Result<T, E>,
+    {
         let partitions = (0..partition_num)
             .map(|_| init_fn(partition_num).map(tokio::sync::Mutex::new))
             .collect::<Result<Vec<tokio::sync::Mutex<T>>, E>>()?;
@@ -184,12 +246,6 @@ where
             partition_mask: partition_num - 1,
             hash_builder,
         })
-    }
-
-    pub async fn lock<K: Eq + Hash>(&self, key: &K) -> tokio::sync::MutexGuard<'_, T> {
-        let mutex = self.get_partition(key);
-
-        mutex.lock().await
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &tokio::sync::Mutex<T> {
@@ -210,6 +266,48 @@ mod tests {
     use hash_ext::{build_fixed_seed_ahasher_builder, SeaHasherBuilder};
 
     use super::*;
+
+    #[test]
+    fn test_new_equivalence() {
+        let init_42 = |_: usize| Ok::<_, ()>(42);
+
+        let test_rwlock_42_bit_len =
+            PartitionedRwLock::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
+                .unwrap();
+        let test_rwlock_42_suggest_cap =
+            PartitionedRwLock::try_new_suggest_cap(init_42, 13, build_fixed_seed_ahasher_builder())
+                .unwrap();
+
+        let test_mutex_42_bit_len =
+            PartitionedMutex::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
+                .unwrap();
+        let test_mutex_42_suggest_cap =
+            PartitionedMutex::try_new_suggest_cap(init_42, 16, build_fixed_seed_ahasher_builder())
+                .unwrap();
+
+        let test_mutex_async_42_bit_len =
+            PartitionedMutexAsync::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
+                .unwrap();
+        let test_mutex_async_42_suggest_cap = PartitionedMutexAsync::try_new_suggest_cap(
+            init_42,
+            13,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            test_rwlock_42_bit_len.partition_mask,
+            test_rwlock_42_suggest_cap.partition_mask
+        );
+        assert_eq!(
+            test_mutex_42_bit_len.partition_mask,
+            test_mutex_42_suggest_cap.partition_mask
+        );
+        assert_eq!(
+            test_mutex_async_42_bit_len.partition_mask,
+            test_mutex_async_42_suggest_cap.partition_mask
+        );
+    }
 
     #[test]
     fn test_partitioned_rwlock() {
@@ -235,7 +333,8 @@ mod tests {
     fn test_partitioned_mutex() {
         let init_hmap = |_: usize| Ok::<_, ()>(HashMap::new());
         let test_locked_map =
-            PartitionedMutex::try_new(init_hmap, 4, build_fixed_seed_ahasher_builder()).unwrap();
+            PartitionedMutex::try_new_bit_len(init_hmap, 4, build_fixed_seed_ahasher_builder())
+                .unwrap();
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -254,7 +353,7 @@ mod tests {
     async fn test_partitioned_mutex_async() {
         let init_hmap = |_: usize| Ok::<_, ()>(HashMap::new());
         let test_locked_map =
-            PartitionedMutexAsync::try_new(init_hmap, 4, SeaHasherBuilder).unwrap();
+            PartitionedMutexAsync::try_new_bit_len(init_hmap, 4, SeaHasherBuilder).unwrap();
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -273,7 +372,8 @@ mod tests {
     fn test_partitioned_mutex_vis_different_partition() {
         let init_vec = |_: usize| Ok::<_, ()>(Vec::<i32>::new());
         let test_locked_map =
-            PartitionedMutex::try_new(init_vec, 4, build_fixed_seed_ahasher_builder()).unwrap();
+            PartitionedMutex::try_new_bit_len(init_vec, 4, build_fixed_seed_ahasher_builder())
+                .unwrap();
         let mutex_first = test_locked_map.get_partition_by_index(0);
 
         let mut _tmp_data = mutex_first.lock().unwrap();
@@ -303,7 +403,7 @@ mod tests {
     async fn test_partitioned_mutex_async_vis_different_partition() {
         let init_vec = |_: usize| Ok::<_, ()>(Vec::<i32>::new());
         let test_locked_map =
-            PartitionedMutexAsync::try_new(init_vec, 4, SeaHasherBuilder).unwrap();
+            PartitionedMutexAsync::try_new_bit_len(init_vec, 4, SeaHasherBuilder).unwrap();
         let mutex_first = test_locked_map.get_partition_by_index(0).await;
 
         let mut _tmp_data = mutex_first.lock().await;

--- a/src/components/partitioned_lock/src/lib.rs
+++ b/src/components/partitioned_lock/src/lib.rs
@@ -36,8 +36,9 @@ impl<T, B> PartitionedRwLock<T, B>
 where
     B: BuildHasher,
 {
-    /// the old way to new a partitioned lock, for Compatibility
-    pub fn try_new_bit_len<F, E>(
+    /// the old way to new a partitioned lock, retained for Compatibility
+    /// the capactity of partition is 2^partition_bit_Len
+    pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
         hash_builder: B,
@@ -50,7 +51,9 @@ where
     }
 
     /// the suggested method of new a partitioned lock
-    pub fn try_new_suggest_cap<F, E>(
+    /// the capactity is the next power of 2 of suggest_cap
+    /// example: suggest_cap = 10, partition_num = 16
+    pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
         hash_builder: B,
@@ -119,7 +122,9 @@ impl<T, B> PartitionedMutex<T, B>
 where
     B: BuildHasher,
 {
-    pub fn try_new_bit_len<F, E>(
+    /// the old way to new a partitioned lock, retained for Compatibility
+    /// the capactity of partition is 2^partition_bit_Len
+    pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
         hash_builder: B,
@@ -131,7 +136,10 @@ where
         PartitionedMutex::try_new_with_partition_num(init_fn, partition_num, hash_builder)
     }
 
-    pub fn try_new_suggest_cap<F, E>(
+    /// the suggested method of new a partitioned lock
+    /// the capactity is the next power of 2 of suggest_cap
+    /// example: suggest_cap = 10, partition _num = 16
+    pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
         hash_builder: B,
@@ -198,7 +206,9 @@ impl<T, B> PartitionedMutexAsync<T, B>
 where
     B: BuildHasher,
 {
-    pub fn try_new_bit_len<F, E>(
+    /// the old way to new a partitioned lock, retained for Compatibility
+    /// the capactity of partition is 2^partition_bit_Len
+    pub fn try_new_with_bit_len<F, E>(
         init_fn: F,
         partition_bit_len: usize,
         hash_builder: B,
@@ -210,7 +220,10 @@ where
         PartitionedMutexAsync::try_new_with_partition_num(init_fn, partition_num, hash_builder)
     }
 
-    pub fn try_new_suggest_cap<F, E>(
+    /// the suggested method of new a partitioned lock
+    /// the capactity is the next power of 2 of suggest _Cap
+    /// example: suggest_cap = 10, partition _num = 16
+    pub fn try_new_with_suggest_cap<F, E>(
         init_fn: F,
         suggest_cap: usize,
         hash_builder: B,
@@ -272,23 +285,32 @@ mod tests {
         let init_42 = |_: usize| Ok::<_, ()>(42);
 
         let test_rwlock_42_bit_len =
-            PartitionedRwLock::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
+            PartitionedRwLock::try_new_with_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
                 .unwrap();
-        let test_rwlock_42_suggest_cap =
-            PartitionedRwLock::try_new_suggest_cap(init_42, 13, build_fixed_seed_ahasher_builder())
-                .unwrap();
+        let test_rwlock_42_suggest_cap = PartitionedRwLock::try_new_with_suggest_cap(
+            init_42,
+            13,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
 
         let test_mutex_42_bit_len =
-            PartitionedMutex::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
+            PartitionedMutex::try_new_with_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
                 .unwrap();
-        let test_mutex_42_suggest_cap =
-            PartitionedMutex::try_new_suggest_cap(init_42, 16, build_fixed_seed_ahasher_builder())
-                .unwrap();
+        let test_mutex_42_suggest_cap = PartitionedMutex::try_new_with_suggest_cap(
+            init_42,
+            16,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
 
-        let test_mutex_async_42_bit_len =
-            PartitionedMutexAsync::try_new_bit_len(init_42, 4, build_fixed_seed_ahasher_builder())
-                .unwrap();
-        let test_mutex_async_42_suggest_cap = PartitionedMutexAsync::try_new_suggest_cap(
+        let test_mutex_async_42_bit_len = PartitionedMutexAsync::try_new_with_bit_len(
+            init_42,
+            4,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
+        let test_mutex_async_42_suggest_cap = PartitionedMutexAsync::try_new_with_suggest_cap(
             init_42,
             13,
             build_fixed_seed_ahasher_builder(),
@@ -312,9 +334,12 @@ mod tests {
     #[test]
     fn test_partitioned_rwlock() {
         let init_hmap = |_: usize| Ok::<_, ()>(HashMap::new());
-        let test_locked_map =
-            PartitionedRwLock::try_new_bit_len(init_hmap, 4, build_fixed_seed_ahasher_builder())
-                .unwrap();
+        let test_locked_map = PartitionedRwLock::try_new_with_bit_len(
+            init_hmap,
+            4,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -332,9 +357,12 @@ mod tests {
     #[test]
     fn test_partitioned_mutex() {
         let init_hmap = |_: usize| Ok::<_, ()>(HashMap::new());
-        let test_locked_map =
-            PartitionedMutex::try_new_bit_len(init_hmap, 4, build_fixed_seed_ahasher_builder())
-                .unwrap();
+        let test_locked_map = PartitionedMutex::try_new_with_bit_len(
+            init_hmap,
+            4,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -353,7 +381,7 @@ mod tests {
     async fn test_partitioned_mutex_async() {
         let init_hmap = |_: usize| Ok::<_, ()>(HashMap::new());
         let test_locked_map =
-            PartitionedMutexAsync::try_new_bit_len(init_hmap, 4, SeaHasherBuilder).unwrap();
+            PartitionedMutexAsync::try_new_with_bit_len(init_hmap, 4, SeaHasherBuilder).unwrap();
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -372,7 +400,7 @@ mod tests {
     fn test_partitioned_mutex_vis_different_partition() {
         let init_vec = |_: usize| Ok::<_, ()>(Vec::<i32>::new());
         let test_locked_map =
-            PartitionedMutex::try_new_bit_len(init_vec, 4, build_fixed_seed_ahasher_builder())
+            PartitionedMutex::try_new_with_bit_len(init_vec, 4, build_fixed_seed_ahasher_builder())
                 .unwrap();
         let mutex_first = test_locked_map.get_partition_by_index(0);
 
@@ -387,9 +415,12 @@ mod tests {
     #[test]
     fn test_partitioned_rwmutex_vis_different_partition() {
         let init_vec = |_: usize| Ok::<_, ()>(Vec::<i32>::new());
-        let test_locked_map =
-            PartitionedRwLock::try_new_bit_len(init_vec, 4, build_fixed_seed_ahasher_builder())
-                .unwrap();
+        let test_locked_map = PartitionedRwLock::try_new_with_bit_len(
+            init_vec,
+            4,
+            build_fixed_seed_ahasher_builder(),
+        )
+        .unwrap();
         let mutex_first = test_locked_map.get_partition_by_index(0);
         let mut _tmp = mutex_first.write().unwrap();
         assert!(mutex_first.try_write().is_err());
@@ -403,7 +434,7 @@ mod tests {
     async fn test_partitioned_mutex_async_vis_different_partition() {
         let init_vec = |_: usize| Ok::<_, ()>(Vec::<i32>::new());
         let test_locked_map =
-            PartitionedMutexAsync::try_new_bit_len(init_vec, 4, SeaHasherBuilder).unwrap();
+            PartitionedMutexAsync::try_new_with_bit_len(init_vec, 4, SeaHasherBuilder).unwrap();
         let mutex_first = test_locked_map.get_partition_by_index(0).await;
 
         let mut _tmp_data = mutex_first.lock().await;


### PR DESCRIPTION
## Rationale
Extended the `try_new` interface while keeping the old one for compatibility.

## Detailed Changes
* Implemented the `try_new_suggest_cap` method, while changing the old `try_new` method to `try_new_bit_len` to ensure compatibility.
* Modified structs and functions that call old interfaces.

## Test Plan
* Added new unit tests
* Passed CI test
