### PR TITLE
fix(comment): update error documentation comment for remote engine service

### DIFF
--- a/src/server/src/grpc/remote_engine_service/error.rs
+++ b/src/server/src/grpc/remote_engine_service/error.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Error definitions for meta event service.
+//! Error definitions for remote engine service.
 
 use generic_error::GenericError;
 use horaedbproto::common::ResponseHeader;


### PR DESCRIPTION
## Rationale
Updating an error comment in the code to reflect the correct service name is needed.

## Test Plan
No need