### PR TITLE
fix: sequence overflow when dropping a table using a message queue as WAL

### DIFF
--- a/src/wal/src/message_queue_impl/wal.rs
+++ b/src/wal/src/message_queue_impl/wal.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_types::SequenceNumber;
+use common_types::{SequenceNumber, MAX_SEQUENCE_NUMBER};
 use generic_error::BoxError;
 use message_queue::{kafka::kafka_impl::KafkaImpl, ConsumeIterator, MessageQueue};
 use runtime::Runtime;
@@ -70,8 +70,13 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
+        let delete_to_sequence_num = if sequence_num == MAX_SEQUENCE_NUMBER {
+            MAX_SEQUENCE_NUMBER
+        } else {
+            sequence_num + 1
+        };
         self.0
-            .mark_delete_to(location, sequence_num + 1)
+            .mark_delete_to(location, delete_to_sequence_num)
             .await
             .box_err()
             .context(Delete)

--- a/src/wal/src/message_queue_impl/wal.rs
+++ b/src/wal/src/message_queue_impl/wal.rs
@@ -70,10 +70,10 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
-        let delete_to_sequence_num = if sequence_num == MAX_SEQUENCE_NUMBER {
-            MAX_SEQUENCE_NUMBER
-        } else {
+        let delete_to_sequence_num = if sequence_num < MAX_SEQUENCE_NUMBER {
             sequence_num + 1
+        } else {
+            MAX_SEQUENCE_NUMBER
         };
         self.0
             .mark_delete_to(location, delete_to_sequence_num)


### PR DESCRIPTION
## Rationale
Fix the issue of sequence overflow when dropping a table using a message queue as WAL.
close #1543 

## Detailed Changes
Check the maximum value of sequence to prevent overflow.

## Test Plan
CI.