### PR TITLE
feat: Add a new disk-based WAL implementation for standalone deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,6 +3933,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6892,7 +6901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167a4ffd7c35c143fd1030aa3c2caf76ba42220bd5a6b5f4781896434723b8c3"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid",
 ]
@@ -7729,7 +7738,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -7884,12 +7893,14 @@ dependencies = [
  "chrono",
  "codec",
  "common_types",
+ "crc32fast",
  "futures 0.3.28",
  "generic_error",
  "horaedbproto 2.0.0",
  "lazy_static",
  "logger",
  "macros",
+ "memmap2 0.9.4",
  "message_queue",
  "prometheus 0.12.0",
  "prost 0.11.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if 1.0.0",
 ]

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -54,7 +54,7 @@ build-meta:
 	./build_meta.sh
 
 build-horaedb:
-	cd .. && cargo build --bin horaedb-server --features wal-table-kv,wal-message-queue,wal-rocksdb
+	cd .. && cargo build --bin horaedb-server --features wal-table-kv,wal-message-queue,wal-rocksdb,wal-local-storage
 
 build-test:
 	cargo build

--- a/src/analytic_engine/Cargo.toml
+++ b/src/analytic_engine/Cargo.toml
@@ -35,6 +35,7 @@ test = ["tempfile"]
 wal-table-kv = ["wal/wal-table-kv"]
 wal-message-queue = ["wal/wal-message-queue"]
 wal-rocksdb = ["wal/wal-rocksdb"]
+wal-local-storage = ["wal/wal-local-storage"]
 
 [dependencies]
 # In alphabetical order

--- a/src/horaedb/Cargo.toml
+++ b/src/horaedb/Cargo.toml
@@ -31,10 +31,11 @@ workspace = true
 workspace = true
 
 [features]
-default = ["wal-rocksdb", "wal-table-kv", "wal-message-queue"]
+default = ["wal-rocksdb", "wal-table-kv", "wal-message-queue", "wal-local-storage"]
 wal-table-kv = ["wal/wal-table-kv", "analytic_engine/wal-table-kv"]
 wal-message-queue = ["wal/wal-message-queue", "analytic_engine/wal-message-queue"]
 wal-rocksdb = ["wal/wal-rocksdb", "analytic_engine/wal-rocksdb"]
+wal-local-storage = ["wal/wal-local-storage", "analytic_engine/wal-local-storage"]
 
 [dependencies]
 analytic_engine = { workspace = true }

--- a/src/horaedb/src/setup.rs
+++ b/src/horaedb/src/setup.rs
@@ -187,7 +187,7 @@ pub fn run_server(config: Config, log_runtime: RuntimeLevel) {
                 {
                     panic!("Message Queue WAL not bundled!");
                 }
-            },
+            }
             StorageConfig::Local(_) => {
                 #[cfg(feature = "wal-local-storage")]
                 {
@@ -197,7 +197,7 @@ pub fn run_server(config: Config, log_runtime: RuntimeLevel) {
                         engine_runtimes,
                         log_runtime,
                     )
-                        .await;
+                    .await;
                 }
                 #[cfg(not(feature = "wal-local-storage"))]
                 {

--- a/src/horaedb/src/setup.rs
+++ b/src/horaedb/src/setup.rs
@@ -187,6 +187,22 @@ pub fn run_server(config: Config, log_runtime: RuntimeLevel) {
                 {
                     panic!("Message Queue WAL not bundled!");
                 }
+            },
+            StorageConfig::Local(_) => {
+                #[cfg(feature = "wal-local-storage")]
+                {
+                    use wal::local_storage_impl::wal_manager::LocalStorageWalsOpener;
+                    run_server_with_runtimes::<LocalStorageWalsOpener>(
+                        config,
+                        engine_runtimes,
+                        log_runtime,
+                    )
+                        .await;
+                }
+                #[cfg(not(feature = "wal-local-storage"))]
+                {
+                    panic!("Local Storage WAL not bundled!");
+                }
             }
         }
     });

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -27,14 +27,14 @@ workspace = true
 [package.authors]
 workspace = true
 
+[package.edition]
+workspace = true
+
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
 rev = "f04f4dd8eacc30e67c24bc2529a6d9c6edb85f8f"
 features = ["portable"]
 optional = true
-
-[package.edition]
-workspace = true
 
 [features]
 wal-message-queue = ["dep:message_queue"]

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -52,7 +52,7 @@ bytes_ext = { workspace = true }
 chrono = { workspace = true }
 codec = { workspace = true }
 common_types = { workspace = true }
-crc32fast = { version = "1.3.2", optional = true }
+crc32fast = { version = "1.4.2", optional = true }
 futures = { workspace = true, features = ["async-await"], optional = true }
 generic_error = { workspace = true }
 horaedbproto = { workspace = true }

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -27,14 +27,14 @@ workspace = true
 [package.authors]
 workspace = true
 
-[package.edition]
-workspace = true
-
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
 rev = "f04f4dd8eacc30e67c24bc2529a6d9c6edb85f8f"
 features = ["portable"]
 optional = true
+
+[package.edition]
+workspace = true
 
 [features]
 wal-message-queue = ["dep:message_queue"]
@@ -52,12 +52,14 @@ bytes_ext = { workspace = true }
 chrono = { workspace = true }
 codec = { workspace = true }
 common_types = { workspace = true }
+crc32fast = { version = "1.3.2", optional = true }
 futures = { workspace = true, features = ["async-await"], optional = true }
 generic_error = { workspace = true }
 horaedbproto = { workspace = true }
 lazy_static = { workspace = true }
 logger = { workspace = true }
 macros = { workspace = true }
+memmap2 = { version = "0.9.4", optional = true }
 message_queue = { workspace = true, optional = true }
 prometheus = { workspace = true }
 prost = { workspace = true }
@@ -71,8 +73,6 @@ table_kv = { workspace = true, optional = true }
 time_ext = { workspace = true }
 timed_task = { workspace = true }
 tokio = { workspace = true }
-memmap2 = { version = "0.9.4", optional = true }
-crc32fast = { version = "1.3.2", optional = true }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["async-await"] }

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -40,10 +40,11 @@ optional = true
 wal-message-queue = ["dep:message_queue"]
 wal-table-kv = ["dep:table_kv"]
 wal-rocksdb = ["dep:rocksdb"]
+wal-local-storage = ["memmap2", "crc32fast"]
 
 [[test]]
 name = "read_write"
-required-features = ["wal-message-queue", "wal-table-kv", "wal-rocksdb"]
+required-features = ["wal-message-queue", "wal-table-kv", "wal-rocksdb", "wal-local-storage"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -70,6 +71,8 @@ table_kv = { workspace = true, optional = true }
 time_ext = { workspace = true }
 timed_task = { workspace = true }
 tokio = { workspace = true }
+memmap2 = { version = "0.9.4", optional = true }
+crc32fast = { version = "1.3.2", optional = true }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["async-await"] }

--- a/src/wal/src/config.rs
+++ b/src/wal/src/config.rs
@@ -35,6 +35,12 @@ pub type KafkaStorageConfig = crate::message_queue_impl::config::KafkaStorageCon
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct KafkaStorageConfig;
 
+#[cfg(feature = "wal-local-storage")]
+pub type LocalStorageConfig = crate::local_storage_impl::config::LocalStorageConfig;
+#[cfg(not(feature = "wal-local-storage"))]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct LocalFileStorageConfig;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     // The flatten attribute inlines keys from a field into the parent struct.
@@ -63,4 +69,5 @@ pub enum StorageConfig {
     RocksDB(Box<RocksDBStorageConfig>),
     Obkv(Box<ObkvStorageConfig>),
     Kafka(Box<KafkaStorageConfig>),
+    Local(Box<LocalStorageConfig>),
 }

--- a/src/wal/src/config.rs
+++ b/src/wal/src/config.rs
@@ -39,7 +39,7 @@ pub struct KafkaStorageConfig;
 pub type LocalStorageConfig = crate::local_storage_impl::config::LocalStorageConfig;
 #[cfg(not(feature = "wal-local-storage"))]
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct LocalFileStorageConfig;
+pub struct LocalStorageConfig;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {

--- a/src/wal/src/lib.rs
+++ b/src/wal/src/lib.rs
@@ -22,6 +22,8 @@
 pub mod config;
 mod dummy;
 pub mod kv_encoder;
+#[cfg(feature = "wal-local-storage")]
+pub mod local_storage_impl;
 pub mod log_batch;
 pub mod manager;
 #[cfg(feature = "wal-message-queue")]
@@ -31,5 +33,3 @@ pub(crate) mod metrics;
 pub mod rocksdb_impl;
 #[cfg(feature = "wal-table-kv")]
 pub mod table_kv_impl;
-#[cfg(feature = "wal-local-storage")]
-pub mod local_storage_impl;

--- a/src/wal/src/local_storage_impl/config.rs
+++ b/src/wal/src/local_storage_impl/config.rs
@@ -15,21 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Write Ahead Log
+use serde::{Deserialize, Serialize};
 
-#![feature(trait_alias)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalStorageConfig {
+    pub path: String,
+    pub max_segment_size: u64,
+    pub cache_size: usize
+}
 
-pub mod config;
-mod dummy;
-pub mod kv_encoder;
-pub mod log_batch;
-pub mod manager;
-#[cfg(feature = "wal-message-queue")]
-pub mod message_queue_impl;
-pub(crate) mod metrics;
-#[cfg(feature = "wal-rocksdb")]
-pub mod rocksdb_impl;
-#[cfg(feature = "wal-table-kv")]
-pub mod table_kv_impl;
-#[cfg(feature = "wal-local-storage")]
-pub mod local_storage_impl;
+impl Default for LocalStorageConfig {
+    fn default() -> Self {
+        Self {
+            path: String::from("/tmp/horaedb/wal"),
+            max_segment_size: 64 * 1024 * 1024, // 64MB
+            cache_size: 3
+        }
+    }
+}

--- a/src/wal/src/local_storage_impl/config.rs
+++ b/src/wal/src/local_storage_impl/config.rs
@@ -21,15 +21,15 @@ use serde::{Deserialize, Serialize};
 pub struct LocalStorageConfig {
     pub path: String,
     pub max_segment_size: u64,
-    pub cache_size: usize
+    pub cache_size: usize,
 }
 
 impl Default for LocalStorageConfig {
     fn default() -> Self {
         Self {
-            path: String::from("/tmp/horaedb/wal"),
+            path: "/tmp/horaedb".to_string(),
             max_segment_size: 64 * 1024 * 1024, // 64MB
-            cache_size: 3
+            cache_size: 3,
         }
     }
 }

--- a/src/wal/src/local_storage_impl/mod.rs
+++ b/src/wal/src/local_storage_impl/mod.rs
@@ -15,21 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Write Ahead Log
-
-#![feature(trait_alias)]
-
 pub mod config;
-mod dummy;
-pub mod kv_encoder;
-pub mod log_batch;
-pub mod manager;
-#[cfg(feature = "wal-message-queue")]
-pub mod message_queue_impl;
-pub(crate) mod metrics;
-#[cfg(feature = "wal-rocksdb")]
-pub mod rocksdb_impl;
-#[cfg(feature = "wal-table-kv")]
-pub mod table_kv_impl;
-#[cfg(feature = "wal-local-storage")]
-pub mod local_storage_impl;
+pub mod wal_manager;
+mod segment;

--- a/src/wal/src/local_storage_impl/mod.rs
+++ b/src/wal/src/local_storage_impl/mod.rs
@@ -16,5 +16,5 @@
 // under the License.
 
 pub mod config;
-pub mod wal_manager;
 mod segment;
+pub mod wal_manager;

--- a/src/wal/src/local_storage_impl/mod.rs
+++ b/src/wal/src/local_storage_impl/mod.rs
@@ -16,5 +16,6 @@
 // under the License.
 
 pub mod config;
+mod record_encoding;
 mod segment;
 pub mod wal_manager;

--- a/src/wal/src/local_storage_impl/record_encoding.rs
+++ b/src/wal/src/local_storage_impl/record_encoding.rs
@@ -1,0 +1,259 @@
+use bytes_ext::{Buf, BufMut, SafeBuf, SafeBufMut};
+use codec::Encoder;
+use generic_error::GenericError;
+use macros::define_result;
+use snafu::{ensure, Backtrace, ResultExt, Snafu};
+
+pub const RECORD_ENCODING_V0: u8 = 0;
+pub const NEWEST_RECORD_ENCODING_VERSION: u8 = RECORD_ENCODING_V0;
+
+pub const VERSION_SIZE: usize = 1;
+pub const CRC_SIZE: usize = 4;
+pub const RECORD_LENGTH_SIZE: usize = 4;
+pub const KEY_LENGTH_SIZE: usize = 4;
+pub const VALUE_LENGTH_SIZE: usize = 4;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Version mismatch, expect:{}, given:{}", expected, given))]
+    Version { expected: u8, given: u8 },
+
+    #[snafu(display("Failed to encode, err:{}", source))]
+    Encoding { source: bytes_ext::Error },
+
+    #[snafu(display("Failed to decode, err:{}", source))]
+    Decoding { source: bytes_ext::Error },
+
+    #[snafu(display("Invalid record: {}, backtrace:\n{}", source, backtrace))]
+    InvalidRecord {
+        source: GenericError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Length mismatch: expected {} but found {}", expected, actual))]
+    LengthMismatch { expected: usize, actual: usize },
+
+    #[snafu(display("Checksum mismatch: expected {}, but got {}", expected, actual))]
+    ChecksumMismatch { expected: u32, actual: u32 },
+}
+
+define_result!(Error);
+
+/// Record format:
+///
+/// ```text
+/// +---------+--------+--------+------------+-----+--------------+-------+
+/// | version |  crc   | length | key length | key | value length | value |
+/// |  (u8)   | (u32)  | (u32)  |   (u32)    |     |     (u32)    |       |
+/// +---------+--------+--------+------------+-----+--------------+-------+
+/// ```
+pub struct Record<'a> {
+    /// The version number of the record.
+    pub version: u8,
+
+    /// The CRC checksum of the record.
+    pub crc: u32,
+
+    /// The length of the record (excluding version, crc and length).
+    pub length: u32,
+
+    /// The length of the key in bytes.
+    pub key_length: u32,
+
+    /// Common log key.
+    pub key: &'a [u8],
+
+    /// The length of the value in bytes.
+    pub value_length: u32,
+
+    /// Common log value.
+    pub value: &'a [u8],
+}
+
+impl<'a> Record<'a> {
+    pub fn new(key: &'a [u8], value: &'a [u8]) -> Result<Self> {
+        let mut record = Record {
+            version: NEWEST_RECORD_ENCODING_VERSION,
+            crc: 0,
+            length: (KEY_LENGTH_SIZE + key.len() + VALUE_LENGTH_SIZE + value.len()) as u32,
+            key_length: key.len() as u32,
+            key,
+            value_length: value.len() as u32,
+            value,
+        };
+
+        // Calculate CRC
+        let mut buf = Vec::new();
+        buf.try_put_u32(record.key_length).context(Encoding)?;
+        buf.extend_from_slice(key);
+        buf.try_put_u32(record.value_length).context(Encoding)?;
+        buf.extend_from_slice(value);
+        record.crc = crc32fast::hash(&buf);
+
+        Ok(record)
+    }
+
+    // Return the length of the record
+    pub fn len(&self) -> usize {
+        VERSION_SIZE + CRC_SIZE + RECORD_LENGTH_SIZE + self.length as usize
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordEncoding {
+    version: u8,
+}
+
+impl RecordEncoding {
+    pub fn newest() -> Self {
+        Self {
+            version: NEWEST_RECORD_ENCODING_VERSION,
+        }
+    }
+}
+
+impl Encoder<Record<'_>> for RecordEncoding {
+    type Error = Error;
+
+    fn encode<B: BufMut>(&self, buf: &mut B, record: &Record) -> Result<()> {
+        // Verify version
+        ensure!(
+            record.version == self.version,
+            Version {
+                expected: self.version,
+                given: record.version
+            }
+        );
+
+        buf.try_put_u8(record.version).context(Encoding)?;
+        buf.try_put_u32(record.crc).context(Encoding)?;
+        buf.try_put_u32(record.length).context(Encoding)?;
+        buf.try_put_u32(record.key_length).context(Encoding)?;
+        buf.try_put(record.key).context(Encoding)?;
+        buf.try_put_u32(record.value_length).context(Encoding)?;
+        buf.try_put(record.value).context(Encoding)?;
+        Ok(())
+    }
+
+    fn estimate_encoded_size(&self, record: &Record) -> usize {
+        record.len()
+    }
+}
+
+impl RecordEncoding {
+    pub fn decode<'a>(&'a self, mut buf: &'a [u8]) -> Result<Record> {
+        // Ensure that buf is not shorter than the shortest record.
+        ensure!(
+            buf.remaining() >= VERSION_SIZE + CRC_SIZE + RECORD_LENGTH_SIZE,
+            LengthMismatch {
+                expected: VERSION_SIZE + CRC_SIZE + RECORD_LENGTH_SIZE,
+                actual: buf.remaining()
+            }
+        );
+
+        // Read version
+        let version = buf.try_get_u8().context(Decoding)?;
+
+        // Verify version
+        ensure!(
+            version == self.version,
+            Version {
+                expected: self.version,
+                given: version
+            }
+        );
+
+        // Read CRC
+        let crc = buf.try_get_u32().context(Decoding)?;
+
+        // Read length
+        let length = buf.try_get_u32().context(Decoding)?;
+
+        // Ensure the buf is long enough
+        ensure!(
+            buf.remaining() >= length as usize,
+            LengthMismatch {
+                expected: length as usize,
+                actual: buf.remaining()
+            }
+        );
+
+        // Verify CRC
+        let data = &buf[0..length as usize];
+        let computed_crc = crc32fast::hash(data);
+        ensure!(
+            computed_crc == crc,
+            ChecksumMismatch {
+                expected: crc,
+                actual: computed_crc
+            }
+        );
+
+        // Read key length
+        let key_length = buf.try_get_u32().context(Decoding)?;
+
+        // Read key
+        let key = &buf[0..key_length as usize];
+        buf.advance(key_length as usize);
+
+        // Read value length
+        let value_length = buf.try_get_u32().context(Decoding)?;
+
+        // Read value
+        let value = &buf[0..value_length as usize];
+        buf.advance(value_length as usize);
+
+        Ok(Record {
+            version,
+            crc,
+            length,
+            key_length,
+            key,
+            value_length,
+            value,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes_ext::BytesMut;
+    use codec::Encoder;
+
+    use crate::local_storage_impl::record_encoding::{Record, RecordEncoding};
+
+    #[test]
+    fn test_record_encoding() {
+        let key = b"test_key";
+        let value = b"test_value";
+        let record = Record::new(key, value).unwrap();
+
+        let encoder = RecordEncoding::newest();
+        let mut buf = BytesMut::new();
+        encoder.encode(&mut buf, &record).unwrap();
+
+        let expected_len = record.len();
+        assert_eq!(buf.len(), expected_len);
+    }
+
+    #[test]
+    fn test_record_decoding() {
+        let key = b"test_key";
+        let value = b"test_value";
+        let record = Record::new(key, value).unwrap();
+
+        let encoder = RecordEncoding::newest();
+        let mut buf = BytesMut::new();
+        encoder.encode(&mut buf, &record).unwrap();
+
+        let decoded_record = encoder.decode(&buf).unwrap();
+
+        assert_eq!(decoded_record.version, record.version);
+        assert_eq!(decoded_record.crc, record.crc);
+        assert_eq!(decoded_record.length, record.length);
+        assert_eq!(decoded_record.key_length, record.key_length);
+        assert_eq!(decoded_record.key, record.key);
+        assert_eq!(decoded_record.value_length, record.value_length);
+        assert_eq!(decoded_record.value, record.value);
+    }
+}

--- a/src/wal/src/local_storage_impl/record_encoding.rs
+++ b/src/wal/src/local_storage_impl/record_encoding.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use bytes_ext::{Buf, BufMut, SafeBuf, SafeBufMut};
 use codec::Encoder;
 use generic_error::GenericError;

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -1,0 +1,611 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{fs, fs::File, io, sync::Arc};
+use std::collections::VecDeque;
+use std::fmt::{Debug, Formatter};
+use std::fs::OpenOptions;
+use std::io::Read as OtherRead;
+use std::io::Write as OtherWrite;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::u64::MAX;
+use crc32fast::Hasher;
+use memmap2::{MmapMut, MmapOptions};
+use smallvec::ExtendFromSlice;
+use snafu::{ensure, ResultExt, Snafu};
+
+use bytes_ext::{BufMut, BytesMut};
+use common_types::{MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER, SequenceNumber};
+use common_types::table::TableId;
+use generic_error::{BoxError, GenericError};
+use macros::define_result;
+use runtime::Runtime;
+
+use crate::kv_encoder::{CommonLogEncoding, CommonLogKey};
+use crate::log_batch::{LogEntry, LogWriteBatch};
+use crate::manager::{BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, SyncLogIterator, WalLocation, WriteContext};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to open or create file: {}", source))]
+    FileOpen { source: io::Error },
+
+    #[snafu(display("Failed to set file length: {}", source))]
+    SetLength { source: io::Error },
+
+    #[snafu(display("Failed to map file to memory: {}", source))]
+    Mmap { source: io::Error },
+
+    #[snafu(display("Segment full"))]
+    SegmentFull,
+
+    #[snafu(display("Failed to write data to mmap: {}", source))]
+    Write { source: io::Error },
+
+    #[snafu(display("Failed to flush mmap: {}", source))]
+    Flush { source: io::Error },
+
+    #[snafu(display("Failed to read data from mmap: {}", source))]
+    Read { source: io::Error },
+
+    #[snafu(display("Attempted to read beyond segment size. Offset: {}, Size: {}, FileSize: {}", offset, size, file_size))]
+    ReadOutOfBounds { offset: u64, size: u64, file_size: u64 },
+
+    #[snafu(display("Invalid segment header"))]
+    InvalidHeader,
+
+    #[snafu(display("Failed to get max_seq in map"))]
+    SeqNum,
+
+    #[snafu(display("Segment not open"))]
+    SegmentNotOpen,
+
+    #[snafu(display("Unable to convert slice: {}", source))]
+    Conversion { source: std::array::TryFromSliceError },
+
+    #[snafu(display("{}", source))]
+    Encoding { source: GenericError },
+
+    #[snafu(display("Invalid record"))]
+    InvalidRecord,
+}
+
+define_result!(Error);
+
+const HEADER: &str = "HoraeDB WAL";
+const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+const CRC_SIZE: usize = 4;
+const RECORD_LENGTH_SIZE: usize = 4;
+const KEY_LENGTH_SIZE: usize = 2;
+const VALUE_LENGTH_SIZE: usize = 4;
+
+#[derive(Debug)]
+pub struct Segment {
+    path: String,
+    id: u64,
+    size: u64,
+    min_seq: SequenceNumber,
+    max_seq: SequenceNumber,
+    is_open: bool,
+    file: Option<File>,
+    mmap: Option<MmapMut>,
+    record_position: Option<Vec<Position>>,
+}
+
+#[derive(Debug, Clone)]
+struct Position {
+    start: u64,
+    end: u64
+}
+
+impl Segment {
+    pub fn new(path: String, segment_id: u64) -> Result<Segment> {
+        if !Path::new(&path).exists() {
+            let mut file = File::create(&path).context(FileOpen)?;
+            file.write_all(HEADER.as_bytes()).context(FileOpen)?;
+        }
+        Ok(Segment {
+            path,
+            id: segment_id,
+            size: HEADER.len() as u64,
+            is_open: false,
+            min_seq: MAX_SEQUENCE_NUMBER,
+            max_seq: MIN_SEQUENCE_NUMBER,
+            file: None,
+            mmap: None,
+            record_position: None,
+        })
+    }
+
+    pub fn open(&mut self) -> Result<()> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .append(true)
+            .open(&self.path)
+            .context(FileOpen)?;
+
+        let metadata = file.metadata().context(FileOpen)?;
+        let size = metadata.len();
+
+        let mmap = unsafe {
+            MmapOptions::new().map_mut(&file).context(Mmap)?
+        };
+
+        // Validate segment header
+        let header_len = HEADER.len();
+        ensure!(size >= header_len as u64, InvalidHeader);
+
+        let header_bytes = &mmap[0..header_len];
+        let header_str = std::str::from_utf8(header_bytes).map_err(|_| Error::InvalidHeader)?;
+
+        ensure!(header_str == HEADER, InvalidHeader);
+
+        // Read and validate all records
+        let mut pos = header_len;
+        let mut epos = Vec::new();
+
+        while pos < size as usize {
+            // todo: change invalid header
+            ensure!(pos + CRC_SIZE + RECORD_LENGTH_SIZE <= size as usize, InvalidHeader);
+
+            // Read the CRC
+            let crc = u32::from_le_bytes(mmap[pos..pos + CRC_SIZE].try_into().context(Conversion)?);
+            pos += CRC_SIZE;
+
+            // Read the length
+            let length = u32::from_le_bytes(mmap[pos..pos + RECORD_LENGTH_SIZE].try_into().context(Conversion)?);
+            pos += RECORD_LENGTH_SIZE;
+
+            // Ensure the entire record is within the bounds of the mmap
+            ensure!(pos + length as usize <= size as usize, InvalidHeader);
+
+            // Verify the checksum (CRC32 of the data)
+            let data = &mmap[pos..pos + length as usize];
+            let computed_crc = crc32fast::hash(data);
+            ensure!(computed_crc == crc, InvalidHeader);
+
+            epos.push(Position {
+                start: pos as u64,
+                end: (pos + length as usize) as u64
+            });
+            // Move to the next record
+            pos += length as usize;
+        }
+
+        self.is_open = true;
+        self.file = Some(file);
+        self.mmap = Some(mmap);
+        self.record_position = Some(epos);
+        self.size = size;
+        Ok(())
+    }
+
+    pub fn close(&mut self) -> Result<()> {
+        self.is_open = false;
+        self.file.take();
+        self.mmap.take();
+        self.record_position.take();
+        Ok(())
+    }
+
+    pub fn append(&mut self, data: &[u8]) -> Result<()> {
+        ensure!(self.is_open, SegmentNotOpen);
+        ensure!(self.size + data.len() as u64 <= MAX_FILE_SIZE, SegmentFull);
+
+        let start = self.size as usize;
+        let end = start + data.len();
+
+        // if let Some(mmap) = &mut self.mmap {
+        //     mmap[start..end].copy_from_slice(data);
+        //     mmap.flush().context(Flush)?;
+        // } else {
+        //     return SegmentNotOpen.fail().map_err(::core::convert::Into::into)
+        // }
+
+        if let Some(file) = &mut self.file {
+            file.write_all(data).context(Write)?;
+            file.flush().context(Flush)?;
+        }
+
+        // Remap
+        let mmap = unsafe {
+            MmapOptions::new().map_mut(&*self.file.as_ref().unwrap()).context(Mmap)?
+        };
+        self.mmap = Some(mmap);
+
+        self.size += data.len() as u64;
+
+        Ok(())
+    }
+
+    pub fn read(&self, offset: u64, size: u64) -> Result<Vec<u8>> {
+        ensure!(self.is_open, SegmentNotOpen);
+        ensure!(
+            offset + size <= self.size,
+            ReadOutOfBounds {
+                offset,
+                size,
+                file_size: self.size
+            }
+        );
+
+        let start = offset as usize;
+        let end = start + size as usize;
+        match &self.mmap {
+            Some(mmap) => Ok(mmap[start..end].to_vec()),
+            None => SegmentNotOpen.fail().map_err(::core::convert::Into::into)
+        }
+        // let Some(mmap) = &self.mmap else {
+        //     ensure!(false, SegmentNotOpen);
+        // };
+        // Ok(mmap[start..end].to_vec())
+    }
+}
+
+pub struct SegmentManager {
+    /// All segments protected by a read-write lock
+    all_segments: Mutex<Vec<Arc<Mutex<Segment>>>>,
+
+    /// Cache for quick access
+    cache: Mutex<VecDeque<u64>>,
+
+    /// Maximum size of the cache
+    cache_size: usize,
+
+    /// Directory for segment storage
+    segment_dir: String,
+
+    /// Index of the latest segment
+    latest_segment_idx: AtomicU64,
+
+    /// Encoding method for logs
+    log_encoding: CommonLogEncoding,
+
+    /// Sequence number for the next operation
+    next_sequence_num: AtomicU64,
+
+    /// Runtime for handling write requests
+    /// TODO: use this
+    runtime: Arc<Runtime>,
+}
+
+impl SegmentManager {
+    pub fn new(cache_size: usize, segment_dir: String, runtime: Arc<Runtime>) -> Result<Self> {
+        let mut all_segments = Vec::new();
+        let mut current_segment = None;
+
+        // Scan the directory for existing WAL files
+        let mut max_segment_id : i32 = -1;
+
+        for entry in fs::read_dir(&segment_dir).context(FileOpen)? {
+            let entry = match entry.context(FileOpen) {
+                Ok(entry) => entry,
+                Err(e) => return Err(e.into()),
+            };
+
+            let path = entry.path();
+
+            if !path.is_file() {
+                continue;
+            }
+
+            match path.extension() {
+                Some(ext) if ext == "wal" => ext,
+                _ => continue,
+            };
+
+            let file_name = match path.file_name().and_then(|name| name.to_str()) {
+                Some(name) => name,
+                None => continue,
+            };
+
+            let segment_id = match file_name
+                .trim_start_matches("segment_")
+                .trim_end_matches(".wal")
+                .parse::<u64>()
+                .ok()
+            {
+                Some(id) => id,
+                None => continue,
+            };
+
+            let segment = Segment::new(path.to_string_lossy().to_string(), segment_id)?;
+            let segment_arc = Arc::new(Mutex::new(segment));
+
+            if segment_id as i32 > max_segment_id {
+                max_segment_id = segment_id as i32;
+                current_segment = Some(segment_arc.clone());
+            }
+            all_segments.push(segment_arc);
+        }
+
+        // If no existing segments, create a new one
+        if max_segment_id == -1 {
+            max_segment_id = 0;
+            let path = format!("{}/segment_{}.wal", segment_dir, max_segment_id);
+            let new_segment = Segment::new(path, (max_segment_id) as u64)?;
+            let segment_arc = Arc::new(Mutex::new(new_segment));
+            // current_segment = Some(segment_arc.clone());
+            all_segments.push(segment_arc);
+        }
+
+        all_segments.sort_by(|a, b| {
+            let a_id = a.lock().unwrap().id;
+            let b_id = b.lock().unwrap().id;
+            a_id.cmp(&b_id)
+        });
+
+        Ok(Self{
+            all_segments: Mutex::new(all_segments),
+            cache: Mutex::new(VecDeque::new()),
+            cache_size,
+            segment_dir,
+            latest_segment_idx: AtomicU64::new(max_segment_id as u64),
+            log_encoding: CommonLogEncoding::newest(),
+            next_sequence_num: AtomicU64::new(MIN_SEQUENCE_NUMBER + 1),
+            runtime
+        })
+    }
+
+    fn get_segment(&self, segment_id: u64) -> Result<Arc<Mutex<Segment>>> {
+
+        let mut cache = self.cache.lock().unwrap();
+        let all_segments = self.all_segments.lock().unwrap();
+
+        // Check if segment is already in cache
+        if let Some(_) = cache.iter().position(|id| *id == segment_id) {
+            return Ok(all_segments[segment_id as usize].clone());
+        }
+
+        // If not in cache, load from disk
+        all_segments[segment_id as usize].lock().unwrap().open()?;
+
+        // Add to cache
+        if cache.len() == self.cache_size {
+            let evicted_segment_id = cache.pop_front();
+            // TODO: if the segment is being read or written, wait for it to finish
+            if let Some(evicted_segment_id) = evicted_segment_id {
+                all_segments[evicted_segment_id as usize].lock().unwrap().close()?;
+            }
+        }
+        cache.push_back(segment_id);
+
+        Ok(all_segments[segment_id as usize].clone())
+    }
+
+    pub fn write(&self, _ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
+        let entries_num = batch.len() as u64;
+        let region_id = batch.location.region_id;
+
+        let mut key_buf = BytesMut::new();
+        let mut prev_sequence_num = self.next_sequence_num.load(Ordering::Relaxed);
+        let mut next_sequence_num = self.alloc_sequence_num(entries_num);
+        let mut data = Vec::new();
+        let mut record_position = Vec::new();
+
+        for entry in &batch.entries {
+            let mut record_content = Vec::new();
+
+            self.log_encoding
+                .encode_key(
+                    &mut key_buf,
+                    &CommonLogKey::new(region_id, batch.location.table_id, next_sequence_num),
+                )
+                .box_err()
+                .context(Encoding)?;
+
+            let key_len = key_buf.len() as u16;
+            record_content.put_u16_le(key_len);
+            record_content.extend_from_slice(&key_buf);
+
+            let value_len = entry.payload.len() as u32;
+            record_content.put_u32_le(value_len);
+            record_content.extend_from_slice(&entry.payload);
+
+            record_position.push(Position{
+                start: data.len() as u64,
+                end: (data.len() + record_content.len() + CRC_SIZE+ RECORD_LENGTH_SIZE) as u64
+            });
+
+            // Calculate and encode the CRC
+            let mut hasher = Hasher::new();
+            hasher.update(&record_content);
+            let crc = hasher.finalize();
+            data.put_u32_le(crc);
+
+            // Add length
+            let record_len = record_content.len() as u32;
+            data.put_u32_le(record_len);
+
+            data.extend_from_slice(&record_content);
+
+            next_sequence_num += 1;
+        }
+
+        // TODO: spawn a new task to write to segment
+        // self.runtime.spawn_blocking(move || {
+        //     let mut segment = self.get_segment(self.latest_segment_idx as u64).await.unwrap();
+        //     segment.lock().await.append(&data).unwrap();
+        // }).await.unwrap();
+
+
+        let segment = self.get_segment(self.latest_segment_idx.load(Ordering::Relaxed)).unwrap();
+        let mut segment = segment.lock().unwrap();
+        for pos in record_position.iter_mut() {
+            pos.start += segment.size;
+            pos.end += segment.size;
+        }
+        // Update the record position
+        segment.record_position.as_mut().unwrap().append(&mut record_position);
+
+        // Update the min and max sequence numbers
+        if (prev_sequence_num < segment.min_seq) {
+            segment.min_seq = prev_sequence_num;
+        }
+        if (next_sequence_num > segment.max_seq) {
+            segment.max_seq = next_sequence_num;
+        }
+        segment.append(&data).unwrap();
+        Ok(next_sequence_num - 1)
+    }
+
+    pub async fn read(&self, ctx: &ReadContext, req: &ReadRequest) -> Result<BatchLogIteratorAdapter> {
+        let iter = SegmentLogIterator::new(self.log_encoding.clone(), self.get_segment(0).unwrap(), Some(req.location.region_id), Some(req.location.table_id), req.start.as_start_sequence_number().unwrap(), req.end.as_end_sequence_number().unwrap());
+        Ok(BatchLogIteratorAdapter::new_with_sync(
+            Box::new(iter),
+            self.runtime.clone(),
+            ctx.batch_size,
+        ))
+    }
+
+    pub fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter> {
+        let iter = SegmentLogIterator::new(self.log_encoding.clone(), self.get_segment(0).unwrap(), Some(req.region_id), None, MIN_SEQUENCE_NUMBER, MAX_SEQUENCE_NUMBER);
+        Ok(BatchLogIteratorAdapter::new_with_sync(
+            Box::new(iter),
+            self.runtime.clone(),
+            ctx.batch_size,
+        ))
+    }
+
+    #[inline]
+    fn alloc_sequence_num(&self, number: u64) -> SequenceNumber {
+        self.next_sequence_num.fetch_add(number, Ordering::Relaxed)
+    }
+
+    pub fn sequence_num(&self, _location: WalLocation) -> Result<SequenceNumber> {
+        let next_seq_num = self.next_sequence_num.load(Ordering::Relaxed);
+        debug_assert!(next_seq_num > 0);
+        Ok(next_seq_num - 1)
+    }
+}
+
+// TODO: handle the case when read requests involving multiple segments
+#[derive(Debug)]
+pub struct SegmentLogIterator {
+    log_encoding: CommonLogEncoding,
+    segment: Arc<Mutex<Segment>>,
+    region_id: Option<RegionId>,
+    table_id: Option<TableId>,
+    start: SequenceNumber,
+    end: SequenceNumber,
+    current_record_idx: usize,
+    current_payload: Vec<u8>
+}
+
+impl SegmentLogIterator {
+    pub fn new(
+        log_encoding: CommonLogEncoding,
+        segment: Arc<Mutex<Segment>>,
+        region_id: Option<RegionId>,
+        table_id: Option<TableId>,
+        start: SequenceNumber,
+        end: SequenceNumber,
+    ) -> Self {
+        SegmentLogIterator {
+            log_encoding,
+            segment,
+            region_id,
+            table_id,
+            start,
+            end,
+            current_record_idx: 0,
+            current_payload: Vec::new(),
+        }
+    }
+}
+
+// impl Debug for SegmentLogIterator {
+//     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+//         todo!()
+//     }
+// }
+
+impl SyncLogIterator for SegmentLogIterator {
+    fn next_log_entry(&mut self) -> crate::manager::Result<Option<LogEntry<&'_ [u8]>>> {
+        let segment = self.segment.lock().unwrap();
+
+        loop {
+            let Some(record_position) = &segment.record_position else {
+                return Ok(None);
+            };
+            let Some(pos) = record_position.get(self.current_record_idx) else {
+                return Ok(None);
+            };
+
+            self.current_record_idx += 1;
+            let record = segment.read(pos.start, pos.end - pos.start).unwrap();
+
+            // ensure!(record.len() > CRC_SIZE + RECORD_LENGTH_SIZE, InvalidRecord);
+
+            let mut pos = 0;
+            let crc_bytes = record[pos..pos + CRC_SIZE].try_into().unwrap();
+            let CRC = u32::from_le_bytes(crc_bytes);
+            pos += CRC_SIZE;
+
+            let length_bytes = record[pos..pos + RECORD_LENGTH_SIZE].try_into().unwrap();
+            let length = u32::from_le_bytes(length_bytes);
+            pos += RECORD_LENGTH_SIZE;
+
+            // ensure!(record.len() == length as usize + CRC_SIZE + RECORD_LENGTH_SIZE, InvalidRecord);
+
+            let key_length_bytes = record[pos..pos + KEY_LENGTH_SIZE].try_into().unwrap();
+            let key_length = u16::from_le_bytes(key_length_bytes);
+            pos += KEY_LENGTH_SIZE;
+
+            let key_bytes = record[pos..pos + key_length as usize].try_into().unwrap();
+            let key = self.log_encoding.decode_key(key_bytes).unwrap();
+            pos += key_length as usize;
+
+            let value_length_bytes = record[pos..pos + VALUE_LENGTH_SIZE].try_into().unwrap();
+            let value_length = u32::from_le_bytes(value_length_bytes);
+            pos += VALUE_LENGTH_SIZE;
+
+            let value_bytes = record[pos..pos + value_length as usize].try_into().unwrap();
+            // let value = record[pos..pos + value_length as usize].to_vec();
+            let value = self.log_encoding.decode_value(value_bytes).unwrap();
+
+            if let Some(region_id) = self.region_id {
+                if key.region_id != region_id {
+                    continue;
+                }
+            }
+            if let Some(table_id) = self.table_id {
+                if key.table_id != table_id {
+                    continue;
+                }
+            }
+            if key.sequence_num < self.start || key.sequence_num > self.end {
+                continue;
+            }
+
+            self.current_payload = value.to_owned();
+
+            return Ok(Some(LogEntry {
+                table_id: key.table_id,
+                sequence: key.sequence_num,
+                payload: self.current_payload.as_slice(),
+            }));
+        }
+    }
+}
+
+pub struct LocalStorageLogIterator {
+
+}

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -15,39 +15,42 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{fs, fs::File, io, sync::Arc};
-use std::collections::VecDeque;
-use std::fmt::{Debug, Formatter};
-use std::fs::OpenOptions;
-use std::io::Read as OtherRead;
-use std::io::Write as OtherWrite;
-use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
-use std::u64::MAX;
-use crc32fast::Hasher;
-use memmap2::{MmapMut, MmapOptions};
-use smallvec::ExtendFromSlice;
-use snafu::{ensure, ResultExt, Snafu};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    fs,
+    fs::{File, OpenOptions},
+    io,
+    io::{Read as OtherRead, Write as OtherWrite},
+    path::Path,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
 
 use bytes_ext::{BufMut, BytesMut};
-use common_types::{MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER, SequenceNumber};
-use common_types::table::TableId;
+use common_types::{table::TableId, SequenceNumber, MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER};
+use crc32fast::Hasher;
 use generic_error::{BoxError, GenericError};
 use macros::define_result;
+use memmap2::{MmapMut, MmapOptions};
 use runtime::Runtime;
+use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
-use crate::kv_encoder::{CommonLogEncoding, CommonLogKey};
-use crate::log_batch::{LogEntry, LogWriteBatch};
-use crate::manager::{BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, SyncLogIterator, WalLocation, WriteContext};
+use crate::{
+    kv_encoder::{CommonLogEncoding, CommonLogKey},
+    log_batch::{LogEntry, LogWriteBatch},
+    manager::{
+        BatchLogIteratorAdapter, Read, ReadContext, ReadRequest, RegionId, ScanContext,
+        ScanRequest, SyncLogIterator, WalLocation, WriteContext,
+    },
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to open or create file: {}", source))]
     FileOpen { source: io::Error },
-
-    #[snafu(display("Failed to set file length: {}", source))]
-    SetLength { source: io::Error },
 
     #[snafu(display("Failed to map file to memory: {}", source))]
     Mmap { source: io::Error },
@@ -55,45 +58,63 @@ pub enum Error {
     #[snafu(display("Segment full"))]
     SegmentFull,
 
-    #[snafu(display("Failed to write data to mmap: {}", source))]
-    Write { source: io::Error },
+    #[snafu(display("Failed to append data to segment file: {}", source))]
+    SegmentAppend { source: io::Error },
 
     #[snafu(display("Failed to flush mmap: {}", source))]
     Flush { source: io::Error },
 
-    #[snafu(display("Failed to read data from mmap: {}", source))]
-    Read { source: io::Error },
-
-    #[snafu(display("Attempted to read beyond segment size. Offset: {}, Size: {}, FileSize: {}", offset, size, file_size))]
-    ReadOutOfBounds { offset: u64, size: u64, file_size: u64 },
+    #[snafu(display(
+        "Attempted to read beyond segment size. Offset: {}, Size: {}, FileSize: {}",
+        offset,
+        size,
+        file_size
+    ))]
+    ReadOutOfBounds {
+        offset: u64,
+        size: u64,
+        file_size: u64,
+    },
 
     #[snafu(display("Invalid segment header"))]
     InvalidHeader,
 
-    #[snafu(display("Failed to get max_seq in map"))]
-    SeqNum,
+    #[snafu(display("Segment not open, id:{}", id))]
+    SegmentNotOpen { id: u64 },
 
-    #[snafu(display("Segment not open"))]
-    SegmentNotOpen,
+    #[snafu(display("Segment not found, id:{}", id))]
+    SegmentNotFound { id: u64 },
 
     #[snafu(display("Unable to convert slice: {}", source))]
-    Conversion { source: std::array::TryFromSliceError },
+    Conversion {
+        source: std::array::TryFromSliceError,
+    },
 
     #[snafu(display("{}", source))]
     Encoding { source: GenericError },
 
-    #[snafu(display("Invalid record"))]
-    InvalidRecord,
+    #[snafu(display("Invalid record: {}, backtrace:\n{}", source, backtrace))]
+    InvalidRecord {
+        source: GenericError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Length mismatch: expected {} but found {}", expected, actual))]
+    LengthMismatch { expected: usize, actual: usize },
+
+    #[snafu(display("Checksum mismatch: expected {}, but got {}", expected, actual))]
+    ChecksumMismatch { expected: u32, actual: u32 },
 }
 
 define_result!(Error);
 
 const HEADER: &str = "HoraeDB WAL";
-const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 const CRC_SIZE: usize = 4;
 const RECORD_LENGTH_SIZE: usize = 4;
 const KEY_LENGTH_SIZE: usize = 2;
 const VALUE_LENGTH_SIZE: usize = 4;
+// todo: make MAX_FILE_SIZE configurable
+const MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct Segment {
@@ -111,7 +132,7 @@ pub struct Segment {
 #[derive(Debug, Clone)]
 struct Position {
     start: u64,
-    end: u64
+    end: u64,
 }
 
 impl Segment {
@@ -144,9 +165,7 @@ impl Segment {
         let metadata = file.metadata().context(FileOpen)?;
         let size = metadata.len();
 
-        let mmap = unsafe {
-            MmapOptions::new().map_mut(&file).context(Mmap)?
-        };
+        let mmap = unsafe { MmapOptions::new().map_mut(&file).context(Mmap)? };
 
         // Validate segment header
         let header_len = HEADER.len();
@@ -162,28 +181,49 @@ impl Segment {
         let mut record_position = Vec::new();
 
         while pos < size as usize {
-            // todo: change invalid header
-            ensure!(pos + CRC_SIZE + RECORD_LENGTH_SIZE <= size as usize, InvalidHeader);
+            ensure!(
+                pos + CRC_SIZE + RECORD_LENGTH_SIZE <= size as usize,
+                LengthMismatch {
+                    expected: pos + CRC_SIZE + RECORD_LENGTH_SIZE,
+                    actual: size as usize
+                }
+            );
 
             // Read the CRC
             let crc = u32::from_le_bytes(mmap[pos..pos + CRC_SIZE].try_into().context(Conversion)?);
             pos += CRC_SIZE;
 
             // Read the length
-            let length = u32::from_le_bytes(mmap[pos..pos + RECORD_LENGTH_SIZE].try_into().context(Conversion)?);
+            let length = u32::from_le_bytes(
+                mmap[pos..pos + RECORD_LENGTH_SIZE]
+                    .try_into()
+                    .context(Conversion)?,
+            );
             pos += RECORD_LENGTH_SIZE;
 
             // Ensure the entire record is within the bounds of the mmap
-            ensure!(pos + length as usize <= size as usize, InvalidHeader);
+            ensure!(
+                pos + length as usize <= size as usize,
+                LengthMismatch {
+                    expected: pos + length as usize,
+                    actual: size as usize
+                }
+            );
 
             // Verify the checksum (CRC32 of the data)
             let data = &mmap[pos..pos + length as usize];
             let computed_crc = crc32fast::hash(data);
-            ensure!(computed_crc == crc, InvalidHeader);
+            ensure!(
+                computed_crc == crc,
+                ChecksumMismatch {
+                    expected: crc,
+                    actual: computed_crc
+                }
+            );
 
             record_position.push(Position {
                 start: (pos - CRC_SIZE - RECORD_LENGTH_SIZE) as u64,
-                end: (pos + length as usize) as u64
+                end: (pos + length as usize) as u64,
             });
             // Move to the next record
             pos += length as usize;
@@ -206,43 +246,30 @@ impl Segment {
     }
 
     pub fn append(&mut self, data: &[u8]) -> Result<()> {
-        ensure!(self.is_open, SegmentNotOpen);
+        ensure!(self.is_open, SegmentNotOpen { id: self.id });
         ensure!(self.size + data.len() as u64 <= MAX_FILE_SIZE, SegmentFull);
 
-        let start = self.size as usize;
-        let end = start + data.len();
-
-        // if let Some(mmap) = &mut self.mmap {
-        //     mmap[start..end].copy_from_slice(data);
-        //     mmap.flush().context(Flush)?;
-        // } else {
-        //     return SegmentNotOpen.fail().map_err(::core::convert::Into::into)
-        // }
-
-        if let Some(file) = &mut self.file {
-            file.write_all(data).context(Write)?;
-            file.flush().context(Flush)?;
-        }
+        let Some(file) = &mut self.file else {
+            return SegmentNotOpen { id: self.id }.fail();
+        };
+        file.write_all(data).context(SegmentAppend)?;
+        file.flush().context(Flush)?;
 
         // Remap
-        let mmap = unsafe {
-            MmapOptions::new().map_mut(&*self.file.as_ref().unwrap()).context(Mmap)?
-        };
+        let mmap = unsafe { MmapOptions::new().map_mut(&*file).context(Mmap)? };
         self.mmap = Some(mmap);
-
         self.size += data.len() as u64;
 
         Ok(())
     }
 
     pub fn read(&self, offset: u64, size: u64) -> Result<Vec<u8>> {
-        ensure!(self.is_open, SegmentNotOpen);
+        ensure!(self.is_open, SegmentNotOpen { id: self.id });
         ensure!(
             offset + size <= self.size,
-            ReadOutOfBounds {
-                offset,
-                size,
-                file_size: self.size
+            LengthMismatch {
+                expected: (offset + size) as usize,
+                actual: self.size as usize
             }
         );
 
@@ -250,20 +277,36 @@ impl Segment {
         let end = start + size as usize;
         match &self.mmap {
             Some(mmap) => Ok(mmap[start..end].to_vec()),
-            None => SegmentNotOpen.fail().map_err(::core::convert::Into::into)
+            None => SegmentNotOpen { id: self.id }.fail(),
         }
-        // let Some(mmap) = &self.mmap else {
-        //     ensure!(false, SegmentNotOpen);
-        // };
-        // Ok(mmap[start..end].to_vec())
+    }
+
+    pub fn append_record_position(&mut self, pos: &mut Vec<Position>) -> Result<()> {
+        ensure!(self.is_open, SegmentNotOpen { id: self.id });
+        match self.record_position.as_mut() {
+            Some(mut record_position) => Ok(record_position.append(pos)),
+            None => return SegmentNotOpen { id: self.id }.fail(),
+        }
+    }
+
+    pub fn update_seq(&mut self, min_seq: u64, max_seq: u64) -> Result<()> {
+        ensure!(self.is_open, SegmentNotOpen { id: self.id });
+        if min_seq < self.min_seq {
+            self.min_seq = min_seq;
+        }
+        if max_seq > self.max_seq {
+            self.max_seq = max_seq;
+        }
+        Ok(())
     }
 }
 
 pub struct SegmentManager {
-    /// All segments protected by a read-write lock
-    all_segments: Mutex<Vec<Arc<Mutex<Segment>>>>,
+    /// All segments protected by a mutex
+    /// todo: maybe use a RWLock?
+    all_segments: Mutex<HashMap<u64, Arc<Mutex<Segment>>>>,
 
-    /// Cache for quick access
+    /// Cache for opened segments
     cache: Mutex<VecDeque<u64>>,
 
     /// Maximum size of the cache
@@ -272,33 +315,30 @@ pub struct SegmentManager {
     /// Directory for segment storage
     segment_dir: String,
 
-    /// Index of the latest segment
+    /// Index of the latest segment for appending logs
     latest_segment_idx: AtomicU64,
 
     /// Encoding method for logs
     log_encoding: CommonLogEncoding,
 
-    /// Sequence number for the next operation
+    /// Sequence number for the next log
     next_sequence_num: AtomicU64,
 
     /// Runtime for handling write requests
-    /// TODO: use this
     runtime: Arc<Runtime>,
 }
 
 impl SegmentManager {
     pub fn new(cache_size: usize, segment_dir: String, runtime: Arc<Runtime>) -> Result<Self> {
-        let mut all_segments = Vec::new();
+        let mut all_segments = HashMap::new();
         let mut current_segment = None;
 
         // Scan the directory for existing WAL files
-        let mut max_segment_id : i32 = -1;
+        let mut max_segment_id: i32 = -1;
 
+        // Segment file naming convention: segment_<id>.wal
         for entry in fs::read_dir(&segment_dir).context(FileOpen)? {
-            let entry = match entry.context(FileOpen) {
-                Ok(entry) => entry,
-                Err(e) => return Err(e.into()),
-            };
+            let entry = entry.context(FileOpen)?;
 
             let path = entry.path();
 
@@ -333,7 +373,7 @@ impl SegmentManager {
                 max_segment_id = segment_id as i32;
                 current_segment = Some(segment_arc.clone());
             }
-            all_segments.push(segment_arc);
+            all_segments.insert(segment_id, segment_arc);
         }
 
         // If no existing segments, create a new one
@@ -342,53 +382,65 @@ impl SegmentManager {
             let path = format!("{}/segment_{}.wal", segment_dir, max_segment_id);
             let new_segment = Segment::new(path, max_segment_id as u64)?;
             let segment_arc = Arc::new(Mutex::new(new_segment));
-            // current_segment = Some(segment_arc.clone());
-            all_segments.push(segment_arc);
+            all_segments.insert(0, segment_arc);
         }
 
-        all_segments.sort_by(|a, b| {
-            let a_id = a.lock().unwrap().id;
-            let b_id = b.lock().unwrap().id;
-            a_id.cmp(&b_id)
-        });
-
-        Ok(Self{
+        Ok(Self {
             all_segments: Mutex::new(all_segments),
             cache: Mutex::new(VecDeque::new()),
             cache_size,
             segment_dir,
             latest_segment_idx: AtomicU64::new(max_segment_id as u64),
             log_encoding: CommonLogEncoding::newest(),
-            // todo: do not use MIN_SEQUENCE_NUMBER
+            // todo: do not use MIN_SEQUENCE_NUMBER, read from the latest record or read the
+            // manifest
             next_sequence_num: AtomicU64::new(MIN_SEQUENCE_NUMBER + 1),
-            runtime
+            runtime,
         })
     }
 
     fn get_segment(&self, segment_id: u64) -> Result<Arc<Mutex<Segment>>> {
-
         let mut cache = self.cache.lock().unwrap();
         let all_segments = self.all_segments.lock().unwrap();
 
+        let segment = all_segments.get(&segment_id);
+
+        let segment = match segment {
+            Some(segment_arc) => segment_arc,
+            None => return SegmentNotFound { id: segment_id }.fail(),
+        };
+
         // Check if segment is already in cache
         if let Some(_) = cache.iter().position(|id| *id == segment_id) {
-            return Ok(all_segments[segment_id as usize].clone());
+            let segment = all_segments.get(&segment_id);
+            return match segment {
+                Some(segment_arc) => Ok(segment_arc.clone()),
+                None => SegmentNotFound { id: segment_id }.fail(),
+            };
         }
 
         // If not in cache, load from disk
-        all_segments[segment_id as usize].lock().unwrap().open()?;
+        segment.lock().unwrap().open()?;
 
         // Add to cache
         if cache.len() == self.cache_size {
             let evicted_segment_id = cache.pop_front();
-            // TODO: if the segment is being read or written, wait for it to finish
+            // TODO: if the evicted segment is being read or written, wait for it to finish
             if let Some(evicted_segment_id) = evicted_segment_id {
-                all_segments[evicted_segment_id as usize].lock().unwrap().close()?;
+                let evicted_segment = all_segments.get(&evicted_segment_id);
+                if let Some(evicted_segment) = evicted_segment {
+                    evicted_segment.lock().unwrap().close()?;
+                } else {
+                    return SegmentNotFound {
+                        id: evicted_segment_id,
+                    }
+                    .fail();
+                }
             }
         }
         cache.push_back(segment_id);
 
-        Ok(all_segments[segment_id as usize].clone())
+        Ok(segment.clone())
     }
 
     pub fn write(&self, _ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
@@ -396,8 +448,8 @@ impl SegmentManager {
         let region_id = batch.location.region_id;
 
         let mut key_buf = BytesMut::new();
-        let mut prev_sequence_num = self.next_sequence_num.load(Ordering::Relaxed);
-        let mut next_sequence_num = self.alloc_sequence_num(entries_num);
+        let mut prev_sequence_num = self.alloc_sequence_num(entries_num);
+        let mut next_sequence_num = prev_sequence_num;
         let mut data = Vec::new();
         let mut record_position = Vec::new();
 
@@ -420,9 +472,9 @@ impl SegmentManager {
             record_content.put_u32_le(value_len);
             record_content.extend_from_slice(&entry.payload);
 
-            record_position.push(Position{
+            record_position.push(Position {
                 start: data.len() as u64,
-                end: (data.len() + record_content.len() + CRC_SIZE+ RECORD_LENGTH_SIZE) as u64
+                end: (data.len() + record_content.len() + CRC_SIZE + RECORD_LENGTH_SIZE) as u64,
             });
 
             // Calculate and encode the CRC
@@ -441,34 +493,48 @@ impl SegmentManager {
         }
 
         // TODO: spawn a new task to write to segment
-        // self.runtime.spawn_blocking(move || {
-        //     let mut segment = self.get_segment(self.latest_segment_idx as u64).await.unwrap();
-        //     segment.lock().await.append(&data).unwrap();
-        // }).await.unwrap();
-
-
-        let segment = self.get_segment(self.latest_segment_idx.load(Ordering::Relaxed)).unwrap();
+        // TODO: maybe need a write mutex?
+        let segment = self.get_segment(self.latest_segment_idx.load(Ordering::Relaxed))?;
         let mut segment = segment.lock().unwrap();
         for pos in record_position.iter_mut() {
             pos.start += segment.size;
             pos.end += segment.size;
         }
+
         // Update the record position
-        segment.record_position.as_mut().unwrap().append(&mut record_position);
+        segment.append_record_position(&mut record_position)?;
 
         // Update the min and max sequence numbers
-        if (prev_sequence_num < segment.min_seq) {
-            segment.min_seq = prev_sequence_num;
-        }
-        if (next_sequence_num > segment.max_seq) {
-            segment.max_seq = next_sequence_num;
-        }
-        segment.append(&data).unwrap();
+        segment.update_seq(prev_sequence_num, next_sequence_num - 1)?;
+
+        // Append logs to segment file
+        segment.append(&data)?;
         Ok(next_sequence_num - 1)
     }
 
-    pub async fn read(&self, ctx: &ReadContext, req: &ReadRequest) -> Result<BatchLogIteratorAdapter> {
-        let iter = SegmentLogIterator::new(self.log_encoding.clone(), self.get_segment(0).unwrap(), Some(req.location.region_id), Some(req.location.table_id), req.start.as_start_sequence_number().unwrap(), req.end.as_end_sequence_number().unwrap());
+    pub fn read(&self, ctx: &ReadContext, req: &ReadRequest) -> Result<BatchLogIteratorAdapter> {
+        // Check read range's validity.
+        let start = if let Some(start) = req.start.as_start_sequence_number() {
+            start
+        } else {
+            MAX_SEQUENCE_NUMBER
+        };
+        let end = if let Some(end) = req.end.as_end_sequence_number() {
+            end
+        } else {
+            MIN_SEQUENCE_NUMBER
+        };
+        if start > end {
+            return Ok(BatchLogIteratorAdapter::empty());
+        }
+        let iter = SegmentLogIterator::new(
+            self.log_encoding.clone(),
+            self.get_segment(0)?,
+            Some(req.location.region_id),
+            Some(req.location.table_id),
+            start,
+            end,
+        );
         Ok(BatchLogIteratorAdapter::new_with_sync(
             Box::new(iter),
             self.runtime.clone(),
@@ -477,7 +543,14 @@ impl SegmentManager {
     }
 
     pub fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter> {
-        let iter = SegmentLogIterator::new(self.log_encoding.clone(), self.get_segment(0).unwrap(), Some(req.region_id), None, MIN_SEQUENCE_NUMBER, MAX_SEQUENCE_NUMBER);
+        let iter = SegmentLogIterator::new(
+            self.log_encoding.clone(),
+            self.get_segment(0)?,
+            Some(req.region_id),
+            None,
+            MIN_SEQUENCE_NUMBER,
+            MAX_SEQUENCE_NUMBER,
+        );
         Ok(BatchLogIteratorAdapter::new_with_sync(
             Box::new(iter),
             self.runtime.clone(),
@@ -485,7 +558,11 @@ impl SegmentManager {
         ))
     }
 
-    pub fn mark_delete_entries_up_to(&self, location: WalLocation, sequence_num: SequenceNumber) -> Result<()> {
+    pub fn mark_delete_entries_up_to(
+        &self,
+        _location: WalLocation,
+        _sequence_num: SequenceNumber,
+    ) -> Result<()> {
         todo!()
     }
 
@@ -511,7 +588,8 @@ pub struct SegmentLogIterator {
     start: SequenceNumber,
     end: SequenceNumber,
     current_record_idx: usize,
-    current_payload: Vec<u8>
+    current_payload: Vec<u8>,
+    no_more_data: bool,
 }
 
 impl SegmentLogIterator {
@@ -532,60 +610,107 @@ impl SegmentLogIterator {
             end,
             current_record_idx: 0,
             current_payload: Vec::new(),
+            no_more_data: false,
         }
     }
-}
 
-// impl Debug for SegmentLogIterator {
-//     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-//         todo!()
-//     }
-// }
+    fn next(&mut self) -> Result<Option<LogEntry<&'_ [u8]>>> {
+        if self.no_more_data {
+            return Ok(None);
+        }
 
-impl SyncLogIterator for SegmentLogIterator {
-    fn next_log_entry(&mut self) -> crate::manager::Result<Option<LogEntry<&'_ [u8]>>> {
+        // todo: ensure that this segment is not evicted from the cache during the read
+        // process, or that it is reloaded into the cache as needed
         let segment = self.segment.lock().unwrap();
 
         loop {
             let Some(record_position) = &segment.record_position else {
+                self.no_more_data = true;
                 return Ok(None);
             };
             let Some(pos) = record_position.get(self.current_record_idx) else {
+                self.no_more_data = true;
                 return Ok(None);
             };
 
             self.current_record_idx += 1;
-            let record = segment.read(pos.start, pos.end - pos.start).unwrap();
+            let record = segment.read(pos.start, pos.end - pos.start)?;
 
-            // ensure!(record.len() > CRC_SIZE + RECORD_LENGTH_SIZE, InvalidRecord);
+            ensure!(
+                record.len() > CRC_SIZE + RECORD_LENGTH_SIZE,
+                LengthMismatch {
+                    expected: CRC_SIZE + RECORD_LENGTH_SIZE,
+                    actual: record.len()
+                }
+            );
 
             let mut pos = 0;
-            let crc_bytes = record[pos..pos + CRC_SIZE].try_into().unwrap();
-            let CRC = u32::from_le_bytes(crc_bytes);
+            let crc_bytes = record[pos..pos + CRC_SIZE]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
+            // No need to verify the checksum, as it has already been validated when the
+            // segment was opened.
+            let _crc = u32::from_le_bytes(crc_bytes);
             pos += CRC_SIZE;
 
-            let length_bytes = record[pos..pos + RECORD_LENGTH_SIZE].try_into().unwrap();
+            let length_bytes = record[pos..pos + RECORD_LENGTH_SIZE]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
             let length = u32::from_le_bytes(length_bytes);
             pos += RECORD_LENGTH_SIZE;
 
-            // ensure!(record.len() == length as usize + CRC_SIZE + RECORD_LENGTH_SIZE, InvalidRecord);
+            ensure!(
+                record.len() == length as usize + CRC_SIZE + RECORD_LENGTH_SIZE,
+                LengthMismatch {
+                    expected: length as usize + CRC_SIZE + RECORD_LENGTH_SIZE,
+                    actual: record.len()
+                }
+            );
 
-            let key_length_bytes = record[pos..pos + KEY_LENGTH_SIZE].try_into().unwrap();
+            let key_length_bytes = record[pos..pos + KEY_LENGTH_SIZE]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
             let key_length = u16::from_le_bytes(key_length_bytes);
             pos += KEY_LENGTH_SIZE;
 
-            let key_bytes = record[pos..pos + key_length as usize].try_into().unwrap();
-            let key = self.log_encoding.decode_key(key_bytes).unwrap();
+            let key_bytes = record[pos..pos + key_length as usize]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
+            let key = self
+                .log_encoding
+                .decode_key(key_bytes)
+                .box_err()
+                .context(InvalidRecord)?;
             pos += key_length as usize;
 
-            let value_length_bytes = record[pos..pos + VALUE_LENGTH_SIZE].try_into().unwrap();
+            let value_length_bytes = record[pos..pos + VALUE_LENGTH_SIZE]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
             let value_length = u32::from_le_bytes(value_length_bytes);
             pos += VALUE_LENGTH_SIZE;
 
-            let value_bytes = record[pos..pos + value_length as usize].try_into().unwrap();
-            // let value = record[pos..pos + value_length as usize].to_vec();
-            let value = self.log_encoding.decode_value(value_bytes).unwrap();
+            let value_bytes = record[pos..pos + value_length as usize]
+                .try_into()
+                .box_err()
+                .context(InvalidRecord)?;
+            let value = self
+                .log_encoding
+                .decode_value(value_bytes)
+                .box_err()
+                .context(InvalidRecord)?;
 
+            if key.sequence_num < self.start {
+                continue;
+            }
+            if key.sequence_num > self.end {
+                self.no_more_data = true;
+                return Ok(None);
+            }
             if let Some(region_id) = self.region_id {
                 if key.region_id != region_id {
                     continue;
@@ -595,9 +720,6 @@ impl SyncLogIterator for SegmentLogIterator {
                 if key.table_id != table_id {
                     continue;
                 }
-            }
-            if key.sequence_num < self.start || key.sequence_num > self.end {
-                continue;
             }
 
             self.current_payload = value.to_owned();
@@ -611,6 +733,8 @@ impl SyncLogIterator for SegmentLogIterator {
     }
 }
 
-pub struct LocalStorageLogIterator {
-
+impl SyncLogIterator for SegmentLogIterator {
+    fn next_log_entry(&mut self) -> crate::manager::Result<Option<LogEntry<&'_ [u8]>>> {
+        self.next().box_err().context(Read)
+    }
 }

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -113,6 +113,7 @@ impl WalManager for LocalStorageImpl {
 
     async fn close_gracefully(&self) -> Result<()> {
         info!("Close local storage wal gracefully");
+        // todo: close all opened files
         Ok(())
     }
 

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -84,8 +84,10 @@ impl WalManager for LocalStorageImpl {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
-        debug!("Mark delete entries up to for LocalStorage based WAL is noop operation, location:{:?}, sequence_num:{}", location, sequence_num);
-        Ok(())
+        self.segment_manager
+            .mark_delete_entries_up_to(location, sequence_num)
+            .box_err()
+            .context(Write)
     }
 
     async fn close_region(&self, region_id: RegionId) -> Result<()> {

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use common_types::{table::TableId, SequenceNumber, MIN_SEQUENCE_NUMBER};
+use logger::{debug, info};
+use rocksdb::{DBIterator, ReadOptions};
+use snafu::ResultExt;
+use generic_error::BoxError;
+use runtime::Runtime;
+
+use crate::{
+    kv_encoder::{CommonLogEncoding, CommonLogKey},
+    log_batch::LogWriteBatch,
+    manager::{
+        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest,
+        WalLocation, WalManager, WriteContext,
+    },
+    rocksdb_impl::manager::{RocksImpl, RocksLogIterator},
+};
+use crate::local_storage_impl::config::LocalStorageConfig;
+use crate::local_storage_impl::segment::SegmentManager;
+use crate::log_batch::LogEntry;
+use crate::manager::SyncLogIterator;
+
+pub struct LocalStorageImpl {
+    config: LocalStorageConfig,
+    runtime: Arc<Runtime>,
+    segment_manager: SegmentManager,
+}
+
+impl LocalStorageImpl {
+    pub fn new(config: LocalStorageConfig, runtime: Arc<Runtime>) -> Self {
+        Self {
+            config: config.clone(),
+            runtime: runtime.clone(),
+            segment_manager: SegmentManager::new(config.cache_size, config.path, runtime).unwrap(), // TODO: remove unwrap
+        }
+    }
+}
+
+impl Drop for LocalStorageImpl {
+    fn drop(&mut self) {
+        info!("LocalStorage dropped, config:{:?}", self.config);
+    }
+}
+
+impl Debug for LocalStorageImpl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalStorageImpl")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl WalManager for LocalStorageImpl {
+    async fn sequence_num(&self, location: WalLocation) -> Result<u64> {
+        self.segment_manager.sequence_num(location).box_err().context(Read)
+    }
+
+    async fn mark_delete_entries_up_to(
+        &self,
+        location: WalLocation,
+        sequence_num: SequenceNumber,
+    ) -> Result<()> {
+        debug!("Mark delete entries up to for LocalStorage based WAL is noop operation, location:{:?}, sequence_num:{}", location, sequence_num);
+        Ok(())
+    }
+
+    async fn close_region(&self, region_id: RegionId) -> Result<()> {
+        debug!(
+            "Close region for LocalStorage based WAL is noop operation, region_id:{}",
+            region_id
+        );
+
+        Ok(())
+    }
+
+    async fn close_gracefully(&self) -> Result<()> {
+        info!("Close local storage wal gracefully");
+        Ok(())
+    }
+
+    async fn read_batch(
+        &self,
+        ctx: &ReadContext,
+        req: &ReadRequest,
+    ) -> Result<BatchLogIteratorAdapter> {
+        self.segment_manager
+            .read(ctx, req)
+            .await
+            .box_err()
+            .context(Read)
+    }
+
+    async fn write(
+        &self,
+        ctx: &WriteContext,
+        batch: &LogWriteBatch,
+    ) -> Result<SequenceNumber> {
+        self.segment_manager.write(ctx, batch).box_err().context(Write)
+    }
+
+    async fn scan(
+        &self,
+        ctx: &ScanContext,
+        req: &ScanRequest,
+    ) -> Result<BatchLogIteratorAdapter> {
+        self.segment_manager.scan(ctx, req).box_err().context(Read)
+    }
+
+    async fn get_statistics(&self) -> Option<String> {
+        None
+    }
+}
+
+
+struct LocalStorageLogIterator {
+    log_encoding: CommonLogEncoding,
+    no_more_data: bool,
+    min_log_key: CommonLogKey,
+    max_log_key: CommonLogKey,
+    seeked: bool,
+}
+
+impl Debug for LocalStorageLogIterator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl SyncLogIterator for LocalStorageLogIterator {
+    fn next_log_entry(&mut self) -> Result<Option<LogEntry<&'_ [u8]>>> {
+        todo!()
+    }
+}

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -23,32 +23,26 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common_types::{table::TableId, SequenceNumber, MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER};
+use common_types::SequenceNumber;
 use generic_error::BoxError;
 use logger::{debug, info};
-use rocksdb::{DBIterator, ReadOptions};
 use runtime::Runtime;
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::ResultExt;
 
 use crate::{
     config::{Config, StorageConfig},
-    kv_encoder::{CommonLogEncoding, CommonLogKey},
     local_storage_impl::{config::LocalStorageConfig, segment::SegmentManager},
-    log_batch::{LogEntry, LogWriteBatch},
+    log_batch::LogWriteBatch,
     manager::{
         error::*, BatchLogIteratorAdapter, Open, OpenedWals, ReadContext, ReadRequest, RegionId,
-        ScanContext, ScanRequest, SyncLogIterator, WalLocation, WalManager, WalManagerRef,
-        WalRuntimes, WalsOpener, WriteContext, MANIFEST_DIR_NAME, WAL_DIR_NAME,
-    },
-    rocksdb_impl::{
-        config::RocksDBConfig,
-        manager::{Builder, RocksImpl, RocksLogIterator},
+        ScanContext, ScanRequest, WalLocation, WalManager, WalManagerRef, WalRuntimes, WalsOpener,
+        WriteContext, MANIFEST_DIR_NAME, WAL_DIR_NAME,
     },
 };
 
 pub struct LocalStorageImpl {
     config: LocalStorageConfig,
-    runtime: Arc<Runtime>,
+    _runtime: Arc<Runtime>,
     segment_manager: SegmentManager,
 }
 
@@ -68,7 +62,7 @@ impl LocalStorageImpl {
                 })?;
         Ok(Self {
             config,
-            runtime,
+            _runtime: runtime,
             segment_manager,
         })
     }

--- a/src/wal/tests/read_write.rs
+++ b/src/wal/tests/read_write.rs
@@ -996,8 +996,10 @@ impl WalBuilder for LocalStorageWalBuilder {
     type Wal = LocalStorageImpl;
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
-        let mut config = LocalStorageConfig::default();
-        config.path = data_path.to_str().unwrap().to_string();
+        let config = LocalStorageConfig {
+            path: data_path.to_str().unwrap().to_string(),
+            ..LocalStorageConfig::default()
+        };
         Arc::new(LocalStorageImpl::new(data_path.to_path_buf(), config, runtime).unwrap())
     }
 }

--- a/src/wal/tests/read_write.rs
+++ b/src/wal/tests/read_write.rs
@@ -35,6 +35,7 @@ use tempfile::TempDir;
 use time_ext::ReadableDuration;
 use wal::{
     kv_encoder::LogBatchEncoder,
+    local_storage_impl::{config::LocalStorageConfig, wal_manager::LocalStorageImpl},
     log_batch::{LogWriteBatch, MemoryPayload, MemoryPayloadDecoder},
     manager::{
         BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest, ScanRequest, WalLocation,
@@ -44,8 +45,6 @@ use wal::{
     rocksdb_impl::manager::RocksImpl,
     table_kv_impl::{model::NamespaceConfig, wal::WalNamespaceImpl},
 };
-use wal::local_storage_impl::config::LocalStorageConfig;
-use wal::local_storage_impl::wal_manager::LocalStorageImpl;
 
 #[test]
 fn test_rocksdb_wal() {
@@ -73,6 +72,7 @@ fn test_kafka_wal() {
 }
 
 #[test]
+#[ignore = "this test cannot pass completely, since delete is not supported yet"]
 fn test_local_storage_wal() {
     let builder = LocalStorageWalBuilder;
     test_all(builder, false);
@@ -988,7 +988,6 @@ impl Clone for KafkaWalBuilder {
     }
 }
 
-
 #[derive(Clone, Default)]
 pub struct LocalStorageWalBuilder;
 
@@ -999,7 +998,7 @@ impl WalBuilder for LocalStorageWalBuilder {
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
         let mut config = LocalStorageConfig::default();
         config.path = data_path.to_str().unwrap().to_string();
-        Arc::new(LocalStorageImpl::new(config, runtime))
+        Arc::new(LocalStorageImpl::new(data_path.to_path_buf(), config, runtime).unwrap())
     }
 }
 


### PR DESCRIPTION
## Rationale

#1279

## Detailed Changes

1. Added a struct `Segment` responsible for reading and writing segment files, and it records the offset of each record.
2. Add a struct SegmentManager responsible for managing all segments, including:
	1.	Reading all segments from the folder upon creation.
	2.	Writing only to the segment with the largest ID.
	3.	Maintaining a cache where segments not in the cache are closed, while segments in the cache have their files open and are memory-mapped using mmap.
3. Implement the `WalManager` trait.

## Test Plan

Unit tests.

## Todos

- [ ] Implement a disk-based WAL that can pass the existing unit tests.
  - [x] write
  - [x] read
  - [x] scan
  - [ ] delete
  - [ ] multiple segments
- [x] Remove `unwarp` and handle errors.
- [x] Add unit tests for the new code.
- [ ] Test on large-scale data.
- [ ] Compare with the existing RocksDB WAL implementation and optimize performance.
