### PR TITLE
feat: Implementing cross-segment read/write for WAL based on local disk

### DIFF
--- a/src/wal/src/local_storage_impl/config.rs
+++ b/src/wal/src/local_storage_impl/config.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalStorageConfig {
     pub path: String,
-    pub max_segment_size: u64,
+    pub max_segment_size: usize,
     pub cache_size: usize,
 }
 

--- a/src/wal/src/local_storage_impl/record_encoding.rs
+++ b/src/wal/src/local_storage_impl/record_encoding.rs
@@ -183,6 +183,7 @@ impl RecordEncoding {
 
         // Read length
         let length = buf.try_get_u32().context(Decoding)?;
+        ensure!(length > 0, LengthMismatch { expected: 1usize, actual: 0usize });
 
         // Ensure the buf is long enough
         ensure!(

--- a/src/wal/src/local_storage_impl/record_encoding.rs
+++ b/src/wal/src/local_storage_impl/record_encoding.rs
@@ -62,6 +62,7 @@ define_result!(Error);
 /// |  (u8)   | (u32)  | (u32)  |   (u64)    |    (u64)     |     (u32)    |       |
 /// +---------+--------+--------+------------+--------------+--------------+-------+
 /// ```
+#[derive(Debug)]
 pub struct Record<'a> {
     /// The version number of the record.
     pub version: u8,

--- a/src/wal/src/local_storage_impl/record_encoding.rs
+++ b/src/wal/src/local_storage_impl/record_encoding.rs
@@ -184,7 +184,13 @@ impl RecordEncoding {
 
         // Read length
         let length = buf.try_get_u32().context(Decoding)?;
-        ensure!(length > 0, LengthMismatch { expected: 1usize, actual: 0usize });
+        ensure!(
+            length > 0,
+            LengthMismatch {
+                expected: 1usize,
+                actual: 0usize
+            }
+        );
 
         // Ensure the buf is long enough
         ensure!(

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -268,6 +268,7 @@ impl Segment {
                 }
                 Err(_) => {
                     // If decoding fails, we've reached the end of valid data
+                    // TODO: too tricky, refactor later
                     break;
                 }
             }
@@ -318,11 +319,11 @@ impl Segment {
         let end = start + data.len();
         mmap[start..end].copy_from_slice(data);
 
-        // Increment the write count
-        self.write_count += 1;
-
         // Update the current size
         self.current_size += data.len();
+
+        // Increment the write count
+        self.write_count += 1;
 
         // Only flush if the write_count reaches FLUSH_INTERVAL
         if self.write_count >= FLUSH_INTERVAL {

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -1243,9 +1243,11 @@ mod tests {
             assert_eq!(expected.payload, actual.payload);
         }
 
-        // Verify that multiple segments were created
-        let all_segments = region.segment_manager.all_segments.lock().unwrap();
-        assert!(all_segments.len() > 1, "Expected multiple segments, but got {}", all_segments.len());
+        {
+            // Verify that multiple segments were created
+            let all_segments = region.segment_manager.all_segments.lock().unwrap();
+            assert!(all_segments.len() > 1, "Expected multiple segments, but got {}", all_segments.len());
+        }
 
         region.close().unwrap()
     }

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -329,7 +329,7 @@ impl Segment {
             // Reset the write count
             self.write_count = 0;
             // Update the last flushed position
-            self.last_flushed_position = self.current_size;
+            self.last_flushed_position = self.current_size + data.len();
         }
 
         // Update the current size

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -324,7 +324,7 @@ impl Segment {
 
         // Only flush if the write_count reaches FLUSH_INTERVAL
         if self.write_count >= FLUSH_INTERVAL {
-            mmap.flush_range(self.last_flushed_position, self.current_size)
+            mmap.flush_range(self.last_flushed_position, self.current_size + data.len())
                 .context(Flush)?;
             // Reset the write count
             self.write_count = 0;

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -319,9 +319,6 @@ impl Segment {
         let end = start + data.len();
         mmap[start..end].copy_from_slice(data);
 
-        // Update the current size
-        self.current_size += data.len();
-
         // Increment the write count
         self.write_count += 1;
 
@@ -334,6 +331,9 @@ impl Segment {
             // Update the last flushed position
             self.last_flushed_position = self.current_size;
         }
+
+        // Update the current size
+        self.current_size += data.len();
 
         Ok(())
     }

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -64,10 +64,10 @@ impl LocalStorageImpl {
             max_segment_size,
             runtime.clone(),
         )
-        .box_err()
-        .context(Open {
-            wal_path: wal_path_str,
-        })?;
+            .box_err()
+            .context(Open {
+                wal_path: wal_path_str,
+            })?;
         Ok(Self {
             config,
             _runtime: runtime,
@@ -139,7 +139,6 @@ impl WalManager for LocalStorageImpl {
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
         self.region_manager
             .write(ctx, batch)
-            .await
             .box_err()
             .context(Write)
     }

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -86,7 +86,6 @@ impl WalManager for LocalStorageImpl {
     async fn sequence_num(&self, location: WalLocation) -> Result<u64> {
         self.region_manager
             .sequence_num(location)
-            .await
             .box_err()
             .context(Read)
     }
@@ -98,7 +97,6 @@ impl WalManager for LocalStorageImpl {
     ) -> Result<()> {
         self.region_manager
             .mark_delete_entries_up_to(location, sequence_num)
-            .await
             .box_err()
             .context(Delete)
     }
@@ -123,19 +121,18 @@ impl WalManager for LocalStorageImpl {
         ctx: &ReadContext,
         req: &ReadRequest,
     ) -> Result<BatchLogIteratorAdapter> {
-        self.region_manager.read(ctx, req).await.box_err().context(Read)
+        self.region_manager.read(ctx, req).box_err().context(Read)
     }
 
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
         self.region_manager
             .write(ctx, batch)
-            .await
             .box_err()
             .context(Write)
     }
 
     async fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter> {
-        self.region_manager.scan(ctx, req).await.box_err().context(Read)
+        self.region_manager.scan(ctx, req).box_err().context(Read)
     }
 
     async fn get_statistics(&self) -> Option<String> {

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -64,10 +64,10 @@ impl LocalStorageImpl {
             max_segment_size,
             runtime.clone(),
         )
-            .box_err()
-            .context(Open {
-                wal_path: wal_path_str,
-            })?;
+        .box_err()
+        .context(Open {
+            wal_path: wal_path_str,
+        })?;
         Ok(Self {
             config,
             _runtime: runtime,

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -106,13 +106,13 @@ impl WalManager for LocalStorageImpl {
             "Close region for LocalStorage based WAL is noop operation, region_id:{}",
             region_id
         );
-
+        self.region_manager.close(region_id).box_err().context(Close)?;
         Ok(())
     }
 
     async fn close_gracefully(&self) -> Result<()> {
         info!("Close local storage wal gracefully");
-        // todo: close all opened files
+        self.region_manager.close_all().box_err().context(Close)?;
         Ok(())
     }
 

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -139,6 +139,7 @@ impl WalManager for LocalStorageImpl {
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
         self.region_manager
             .write(ctx, batch)
+            .await
             .box_err()
             .context(Write)
     }

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -52,13 +52,22 @@ impl LocalStorageImpl {
         config: LocalStorageConfig,
         runtime: Arc<Runtime>,
     ) -> Result<Self> {
-        let LocalStorageConfig { cache_size, max_segment_size, .. } = config.clone();
+        let LocalStorageConfig {
+            cache_size,
+            max_segment_size,
+            ..
+        } = config.clone();
         let wal_path_str = wal_path.to_str().unwrap().to_string();
-        let region_manager = RegionManager::new(wal_path_str.clone(), cache_size, max_segment_size, runtime.clone())
-            .box_err()
-            .context(Open {
-                wal_path: wal_path_str,
-            })?;
+        let region_manager = RegionManager::new(
+            wal_path_str.clone(),
+            cache_size,
+            max_segment_size,
+            runtime.clone(),
+        )
+        .box_err()
+        .context(Open {
+            wal_path: wal_path_str,
+        })?;
         Ok(Self {
             config,
             _runtime: runtime,
@@ -106,7 +115,10 @@ impl WalManager for LocalStorageImpl {
             "Close region for LocalStorage based WAL is noop operation, region_id:{}",
             region_id
         );
-        self.region_manager.close(region_id).box_err().context(Close)?;
+        self.region_manager
+            .close(region_id)
+            .box_err()
+            .context(Close)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Rationale
Improving WAL based on local disk.

This is a follow-up task for #1552.

## Detailed Changes
1. Make MAX_FILE_SIZE configurable.
2. Allocate enough space when creating a segment to avoid remapping when appending to the segment.​
3. Add `MultiSegmentLogIterator` to enable cross-segment reading.
4. When writing, if the current segment has insufficient space, create a new segment and write to the new segment.​

## Test Plan
Unit test.