### PR TITLE
feat: Implement delete operation for WAL based on local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8219,6 +8219,7 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 name = "wal"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes_ext",
  "chrono",

--- a/src/analytic_engine/src/compaction/scheduler.rs
+++ b/src/analytic_engine/src/compaction/scheduler.rs
@@ -87,8 +87,10 @@ impl Default for SchedulerConfig {
             // 30 seconds schedule interval.
             schedule_interval: ReadableDuration(Duration::from_secs(30)),
             max_ongoing_tasks: 8,
-            // flush_interval default is 5h.
-            max_unflushed_duration: ReadableDuration(Duration::from_secs(60 * 60 * 5)),
+            // flush_interval default is 60s.
+            // The previous 5h duration for the local storage WAL is too long, which results in many
+            // segment files not being deleted in a timely manner.
+            max_unflushed_duration: ReadableDuration(Duration::from_secs(60)),
             memory_limit: ReadableSize::gb(4),
             max_pending_compaction_tasks: 1024,
         }

--- a/src/analytic_engine/src/compaction/scheduler.rs
+++ b/src/analytic_engine/src/compaction/scheduler.rs
@@ -87,10 +87,8 @@ impl Default for SchedulerConfig {
             // 30 seconds schedule interval.
             schedule_interval: ReadableDuration(Duration::from_secs(30)),
             max_ongoing_tasks: 8,
-            // flush_interval default is 60s.
-            // The previous 5h duration for the local storage WAL is too long, which results in many
-            // segment files not being deleted in a timely manner.
-            max_unflushed_duration: ReadableDuration(Duration::from_secs(60)),
+            // flush_interval default is 5h.
+            max_unflushed_duration: ReadableDuration(Duration::from_secs(60 * 60 * 5)),
             memory_limit: ReadableSize::gb(4),
             max_pending_compaction_tasks: 1024,
         }

--- a/src/analytic_engine/src/instance/write.rs
+++ b/src/analytic_engine/src/instance/write.rs
@@ -531,21 +531,6 @@ impl<'a> Writer<'a> {
                 e
             })?;
 
-        // When wal is disabled, there is no need to do this check.
-        if !self.instance.disable_wal {
-            // NOTE: Currently write wal will only increment seq by one,
-            // this may change in future.
-            let last_seq = table_data.last_sequence();
-            if sequence != last_seq + 1 {
-                warn!(
-                    "Sequence must be consecutive, table:{}, table_id:{}, last_sequence:{}, wal_sequence:{}",
-                    table_data.name,table_data.id,
-                    table_data.last_sequence(),
-                    sequence
-                );
-            }
-        }
-
         debug!(
             "Instance write finished, update sequence, table:{}, table_id:{} last_sequence:{}",
             table_data.name, table_data.id, sequence

--- a/src/wal/Cargo.toml
+++ b/src/wal/Cargo.toml
@@ -47,6 +47,7 @@ name = "read_write"
 required-features = ["wal-message-queue", "wal-table-kv", "wal-rocksdb", "wal-local-storage"]
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes_ext = { workspace = true }
 chrono = { workspace = true }

--- a/src/wal/src/local_storage_impl/config.rs
+++ b/src/wal/src/local_storage_impl/config.rs
@@ -18,6 +18,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct LocalStorageConfig {
     pub path: String,
     pub max_segment_size: usize,

--- a/src/wal/src/local_storage_impl/config.rs
+++ b/src/wal/src/local_storage_impl/config.rs
@@ -20,16 +20,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LocalStorageConfig {
-    pub path: String,
-    pub max_segment_size: usize,
+    pub data_dir: String,
+    pub segment_size: usize,
     pub cache_size: usize,
 }
 
 impl Default for LocalStorageConfig {
     fn default() -> Self {
         Self {
-            path: "/tmp/horaedb".to_string(),
-            max_segment_size: 64 * 1024 * 1024, // 64MB
+            data_dir: "/tmp/horaedb".to_string(),
+            segment_size: 64 * 1024 * 1024, // 64MB
             cache_size: 3,
         }
     }

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -1201,7 +1201,6 @@ impl MultiSegmentLogIterator {
         }
 
         let segment = self.segments[self.current_segment_idx].clone();
-        // let segment = self.segment_manager.get_segment(segment)?;
         let iterator = SegmentLogIterator::new(
             self.log_encoding.clone(),
             self.record_encoding.clone(),

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -864,6 +864,8 @@ impl RegionManager {
         segment_size: usize,
         runtime: Arc<Runtime>,
     ) -> Result<Self> {
+        fs::create_dir_all(&root_dir).context(DirOpen)?;
+        
         let mut regions = HashMap::new();
 
         // Naming conversion: <root_dir>/<region_id>

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -522,9 +522,10 @@ impl SegmentManager {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
-        let current_segment_id = self.current_segment.lock().unwrap().lock().unwrap().id;
-        let mut segments_to_remove = Vec::new();
+        let current_segment = self.current_segment.lock().unwrap();
+        let current_segment_id = current_segment.lock().unwrap().id;
         let mut all_segments = self.all_segments.lock().unwrap();
+        let mut segments_to_remove = Vec::new();
 
         for (_, segment) in all_segments.iter() {
             let mut guard = segment.lock().unwrap();
@@ -550,6 +551,7 @@ impl SegmentManager {
         }
 
         drop(all_segments);
+        drop(current_segment);
 
         // Delete segments on disk
         for (_, segment) in segments_to_remove.iter() {

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -522,8 +522,7 @@ impl SegmentManager {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
-        let current_segment = self.current_segment.lock().unwrap();
-        let current_segment_id = current_segment.lock().unwrap().id;
+        let current_segment_id = self.current_segment.lock().unwrap().lock().unwrap().id;
         let mut all_segments = self.all_segments.lock().unwrap();
         let mut segments_to_remove = Vec::new();
 
@@ -551,7 +550,6 @@ impl SegmentManager {
         }
 
         drop(all_segments);
-        drop(current_segment);
 
         // Delete segments on disk
         for (_, segment) in segments_to_remove.iter() {

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -494,7 +494,7 @@ impl SegmentManager {
         if guard.mmap.is_some() {
             return Ok(());
         }
-        
+
         let mut cache = self.cache.lock().unwrap();
 
         let already_opened = cache.iter().any(|(id, _)| *id == guard.id);

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -491,6 +491,10 @@ impl SegmentManager {
     /// Open segment if it is not in cache, need to acquire the lock outside
     /// otherwise the segment may get closed again.
     fn open_segment(&self, guard: &mut Segment, segment: Arc<Mutex<Segment>>) -> Result<()> {
+        if guard.mmap.is_some() {
+            return Ok(());
+        }
+        
         let mut cache = self.cache.lock().unwrap();
 
         let already_opened = cache.iter().any(|(id, _)| *id == guard.id);

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -1261,7 +1261,7 @@ mod tests {
         assert_eq!(segment.version, NEWEST_WAL_SEGMENT_VERSION);
         assert_eq!(segment.path, path);
         assert_eq!(segment.id, 0);
-        assert_eq!(segment.current_size, SEGMENT_HEADER.len());
+        assert_eq!(segment.current_size, SEGMENT_HEADER.len() + VERSION_SIZE);
 
         let segment_content = fs::read(path).unwrap();
         assert_eq!(segment_content[0], NEWEST_WAL_SEGMENT_VERSION);

--- a/src/wal/src/local_storage_impl/segment.rs
+++ b/src/wal/src/local_storage_impl/segment.rs
@@ -544,14 +544,14 @@ impl SegmentManager {
             }
         }
 
-        // Delete all segments in memory
+        // Delete segments in all_segments
         for (segment_id, _) in segments_to_remove.iter() {
             all_segments.remove(segment_id);
         }
 
         drop(all_segments);
 
-        // Delete all segments on disk
+        // Delete segments on disk
         for (_, segment) in segments_to_remove.iter() {
             segment.lock().unwrap().delete()?;
         }
@@ -588,7 +588,7 @@ impl SegmentManager {
             }
         }
 
-        // Sort by id
+        // Sort by segment id
         relevant_segments.sort_by_key(|(id, _)| *id);
 
         // id is not needed, so remove it
@@ -1356,8 +1356,6 @@ mod tests {
             runtime,
         )
         .unwrap();
-
-        // let _segment = region.segment_manager.get_segment(0).unwrap();
 
         region.close().unwrap()
     }

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -142,10 +142,7 @@ impl WalManager for LocalStorageImpl {
     }
 
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
-        debug!(
-            "Write batch to LocalStorage based WAL, ctx:{:?}, batch:{:?}",
-            ctx, batch
-        );
+        debug!("Write batch to LocalStorage based WAL, ctx:{:?}", ctx);
         self.region_manager
             .write(ctx, batch)
             .box_err()

--- a/src/wal/src/local_storage_impl/wal_manager.rs
+++ b/src/wal/src/local_storage_impl/wal_manager.rs
@@ -54,14 +54,14 @@ impl LocalStorageImpl {
     ) -> Result<Self> {
         let LocalStorageConfig {
             cache_size,
-            max_segment_size,
+            segment_size,
             ..
         } = config.clone();
         let wal_path_str = wal_path.to_str().unwrap().to_string();
         let region_manager = RegionManager::new(
             wal_path_str.clone(),
             cache_size,
-            max_segment_size,
+            segment_size,
             runtime.clone(),
         )
         .box_err()
@@ -104,6 +104,10 @@ impl WalManager for LocalStorageImpl {
         location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
+        debug!(
+            "Mark delete entries up to {} for location:{:?}",
+            sequence_num, location
+        );
         self.region_manager
             .mark_delete_entries_up_to(location, sequence_num)
             .box_err()
@@ -111,10 +115,7 @@ impl WalManager for LocalStorageImpl {
     }
 
     async fn close_region(&self, region_id: RegionId) -> Result<()> {
-        debug!(
-            "Close region for LocalStorage based WAL is noop operation, region_id:{}",
-            region_id
-        );
+        debug!("Close region {} for LocalStorage based WAL", region_id);
         self.region_manager
             .close(region_id)
             .box_err()
@@ -133,10 +134,18 @@ impl WalManager for LocalStorageImpl {
         ctx: &ReadContext,
         req: &ReadRequest,
     ) -> Result<BatchLogIteratorAdapter> {
+        debug!(
+            "Read batch from LocalStorage based WAL, ctx:{:?}, req:{:?}",
+            ctx, req
+        );
         self.region_manager.read(ctx, req).box_err().context(Read)
     }
 
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
+        debug!(
+            "Write batch to LocalStorage based WAL, ctx:{:?}, batch:{:?}",
+            ctx, batch
+        );
         self.region_manager
             .write(ctx, batch)
             .box_err()
@@ -144,6 +153,10 @@ impl WalManager for LocalStorageImpl {
     }
 
     async fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter> {
+        debug!(
+            "Scan from LocalStorage based WAL, ctx:{:?}, req:{:?}",
+            ctx, req
+        );
         self.region_manager.scan(ctx, req).box_err().context(Read)
     }
 
@@ -181,7 +194,7 @@ impl WalsOpener for LocalStorageWalsOpener {
         };
 
         let write_runtime = runtimes.write_runtime.clone();
-        let data_path = Path::new(&local_storage_wal_config.path);
+        let data_path = Path::new(&local_storage_wal_config.data_dir);
 
         let data_wal = if config.disable_data {
             Arc::new(crate::dummy::DoNothing)

--- a/src/wal/tests/read_write.rs
+++ b/src/wal/tests/read_write.rs
@@ -996,7 +996,7 @@ impl WalBuilder for LocalStorageWalBuilder {
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
         let config = LocalStorageConfig {
-            path: data_path.to_str().unwrap().to_string(),
+            data_dir: data_path.to_str().unwrap().to_string(),
             ..LocalStorageConfig::default()
         };
         Arc::new(LocalStorageImpl::new(data_path.to_path_buf(), config, runtime).unwrap())

--- a/src/wal/tests/read_write.rs
+++ b/src/wal/tests/read_write.rs
@@ -72,7 +72,6 @@ fn test_kafka_wal() {
 }
 
 #[test]
-#[ignore = "this test cannot pass completely, since delete is not supported yet"]
 fn test_local_storage_wal() {
     let builder = LocalStorageWalBuilder;
     test_all(builder, false);


### PR DESCRIPTION
## Rationale

Currently the WAL based on the local disk does not support the delete function. This PR implements that functionality.

This is a follow-up task of #1552 and #1556.

## Detailed Changes

1. For each `Segment`, add a hashmap to record the minimum and maximum sequence numbers of all tables within that segment. During `delete` and `write` operations, this hashmap will be updated. During read operations, logs will be filtered based on this hashmap.

2. During the `delete` operation, based on the aforementioned hashmap, if all logs of all tables in a read-only segment (a segment that is not currently being written to) are marked as deleted, the segment file will be physically deleted from the disk.

## Test Plan

Unit test, TSBS and running a script locally that repeatedly inserts data, forcibly kills, and restarts the database process to test persistence.
