### PR TITLE
chore: record replay cost in log

### DIFF
--- a/src/analytic_engine/src/instance/wal_replayer.rs
+++ b/src/analytic_engine/src/instance/wal_replayer.rs
@@ -37,7 +37,6 @@ use logger::{debug, error, info, trace, warn};
 use prometheus::{exponential_buckets, register_histogram, Histogram};
 use snafu::ResultExt;
 use table_engine::table::TableId;
-use time_ext::current_time_millis;
 use tokio::sync::{Mutex, MutexGuard};
 use wal::{
     log_batch::LogEntry,

--- a/src/analytic_engine/src/instance/wal_replayer.rs
+++ b/src/analytic_engine/src/instance/wal_replayer.rs
@@ -22,6 +22,7 @@ use std::{
     fmt::Display,
     ops::Range,
     sync::Arc,
+    time::Instant,
 };
 
 use async_trait::async_trait;
@@ -36,6 +37,7 @@ use logger::{debug, error, info, trace, warn};
 use prometheus::{exponential_buckets, register_histogram, Histogram};
 use snafu::ResultExt;
 use table_engine::table::TableId;
+use time_ext::current_time_millis;
 use tokio::sync::{Mutex, MutexGuard};
 use wal::{
     log_batch::LogEntry,
@@ -120,15 +122,15 @@ impl<'a> WalReplayer<'a> {
     /// Replay tables and return the failed tables and the causes.
     pub async fn replay(&mut self) -> Result<FailedTables> {
         // Build replay action according to mode.
+        let table_num = self.table_datas.len();
         info!(
-            "Replay wal logs begin, context:{}, tables:{:?}",
+            "Replay wal logs begin, context:{}, table_num:{table_num}, tables:{:?}",
             self.context, self.table_datas
         );
+        let begin = Instant::now();
         let result = self.replay.run(&self.context, self.table_datas).await;
-        info!(
-            "Replay wal logs finish, context:{}, tables:{:?}",
-            self.context, self.table_datas,
-        );
+        let cost = Instant::now().duration_since(begin);
+        info!("Replay wal logs finish, table_num:{table_num}, cost:{cost:?}");
 
         result
     }

--- a/src/analytic_engine/src/lib.rs
+++ b/src/analytic_engine/src/lib.rs
@@ -204,7 +204,7 @@ impl Default for Config {
             wal_encode: WalEncodeConfig::default(),
             wal: WalConfig::default(),
             remote_engine_client: remote_engine_client::config::Config::default(),
-            recover_mode: RecoverMode::TableBased,
+            recover_mode: RecoverMode::ShardBased,
             metrics: MetricsOptions::default(),
         }
     }

--- a/src/server/src/http.rs
+++ b/src/server/src/http.rs
@@ -255,7 +255,6 @@ impl Service {
             .or(self.wal_stats())
             .or(self.query_push_down())
             .or(self.slow_threshold())
-            .with(warp::log("http_requests"))
             .with(warp::log::custom(|info| {
                 let path = info.path();
                 // Don't record /debug API


### PR DESCRIPTION
## Rationale


## Detailed Changes
1. Add replay cost in log
2. Remove verbose http log
3. Recover default to shard based, which is faster in most wal implementation.

## Test Plan
