### PR TITLE
feat: use multithreading to optimize WAL replayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "arc-swap 1.6.0",
  "arena",
  "arrow 49.0.0",
+ "async-scoped",
  "async-stream",
  "async-trait",
  "atomic_enum",
@@ -762,6 +763,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures 0.3.28",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]

--- a/src/analytic_engine/Cargo.toml
+++ b/src/analytic_engine/Cargo.toml
@@ -43,6 +43,7 @@ anyhow = { workspace = true }
 arc-swap = "1.4.0"
 arena = { workspace = true }
 arrow = { workspace = true }
+async-scoped = { version = "0.9.0", features = ["use-tokio"] }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 atomic_enum = { workspace = true }

--- a/src/analytic_engine/src/instance/wal_replayer.rs
+++ b/src/analytic_engine/src/instance/wal_replayer.rs
@@ -30,14 +30,13 @@ use common_types::{
     schema::{IndexInWriterSchema, Schema},
     table::ShardId,
 };
-use futures::StreamExt;
 use generic_error::BoxError;
 use lazy_static::lazy_static;
 use logger::{debug, error, info, trace, warn};
 use prometheus::{exponential_buckets, register_histogram, Histogram};
 use snafu::ResultExt;
 use table_engine::table::TableId;
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard, Semaphore};
 use wal::{
     log_batch::LogEntry,
     manager::{
@@ -189,22 +188,23 @@ impl Replay for TableBasedReplay {
             ..Default::default()
         };
 
-        let mut tasks = futures::stream::iter(
-            table_datas
-                .iter()
-                .map(|table_data| {
-                    let table_id = table_data.id;
-                    let read_ctx = &read_ctx;
-                    async move {
-                        let ret = Self::recover_table_logs(context, table_data, read_ctx).await;
-                        (table_id, ret)
-                    }
-                })
-                .collect::<Vec<_>>(),
-        )
-        .buffer_unordered(20);
-        while let Some((table_id, ret)) = tasks.next().await {
-            if let Err(e) = ret {
+        let ((), results) = async_scoped::TokioScope::scope_and_block(|scope| {
+            // Run at most 20 tasks in parallel
+            let semaphore = Arc::new(Semaphore::new(20));
+            for table_data in table_datas {
+                let table_id = table_data.id;
+                let read_ctx = &read_ctx;
+                let semaphore = semaphore.clone();
+                scope.spawn(async move {
+                    let _permit = semaphore.acquire().await.unwrap();
+                    let ret = Self::recover_table_logs(context, table_data, read_ctx).await;
+                    (table_id, ret)
+                });
+            }
+        });
+
+        for result in results.into_iter().flatten() {
+            if let (table_id, Err(e)) = result {
                 // If occur error, mark this table as failed and store the cause.
                 failed_tables.insert(table_id, e);
             }
@@ -345,7 +345,7 @@ impl RegionBasedReplay {
                 table_data: table_data.clone(),
                 serial_exec,
             };
-            serial_exec_ctxs.insert(table_data.id, serial_exec_ctx);
+            serial_exec_ctxs.insert(table_data.id, Mutex::new(serial_exec_ctx));
             table_datas_by_id.insert(table_data.id.as_u64(), table_data.clone());
         }
 
@@ -353,7 +353,7 @@ impl RegionBasedReplay {
         let schema_provider = TableSchemaProviderAdapter {
             table_datas: table_datas_by_id.clone(),
         };
-        let serial_exec_ctxs = Arc::new(Mutex::new(serial_exec_ctxs));
+        let serial_exec_ctxs = serial_exec_ctxs;
         // Split and replay logs.
         loop {
             let _timer = PULL_LOGS_DURATION_HISTOGRAM.start_timer();
@@ -381,49 +381,53 @@ impl RegionBasedReplay {
     async fn replay_single_batch(
         context: &ReplayContext,
         log_batch: &VecDeque<LogEntry<ReadPayload>>,
-        serial_exec_ctxs: &Arc<Mutex<HashMap<TableId, SerialExecContext<'_>>>>,
+        serial_exec_ctxs: &HashMap<TableId, Mutex<SerialExecContext<'_>>>,
         failed_tables: &mut FailedTables,
     ) -> Result<()> {
         let mut table_batches = Vec::new();
         // TODO: No `group_by` method in `VecDeque`, so implement it manually here...
         Self::split_log_batch_by_table(log_batch, &mut table_batches);
 
-        // TODO: Replay logs of different tables in parallel.
-        let mut replay_tasks = Vec::with_capacity(table_batches.len());
-        for table_batch in table_batches {
-            // Some tables may have failed in previous replay, ignore them.
-            if failed_tables.contains_key(&table_batch.table_id) {
-                continue;
-            }
-            let log_entries: Vec<_> = table_batch
-                .ranges
-                .iter()
-                .flat_map(|range| log_batch.range(range.clone()))
-                .collect();
+        let ((), results) = async_scoped::TokioScope::scope_and_block(|scope| {
+            // Run at most 20 tasks in parallel
+            let semaphore = Arc::new(Semaphore::new(20));
 
-            let serial_exec_ctxs = serial_exec_ctxs.clone();
-            replay_tasks.push(async move {
-                // Some tables may have been moved to other shards or dropped, ignore such logs.
-                if let Some(ctx) = serial_exec_ctxs.lock().await.get_mut(&table_batch.table_id) {
-                    let result = replay_table_log_entries(
-                        &context.flusher,
-                        context.max_retry_flush_limit,
-                        &mut ctx.serial_exec,
-                        &ctx.table_data,
-                        log_entries.into_iter(),
-                    )
-                    .await;
-                    (table_batch.table_id, Some(result))
-                } else {
-                    (table_batch.table_id, None)
+            for table_batch in table_batches {
+                // Some tables may have failed in previous replay, ignore them.
+                if failed_tables.contains_key(&table_batch.table_id) {
+                    continue;
                 }
-            });
-        }
+                let log_entries: Vec<_> = table_batch
+                    .ranges
+                    .iter()
+                    .flat_map(|range| log_batch.range(range.clone()))
+                    .collect();
+                let semaphore = semaphore.clone();
 
-        // Run at most 20 tasks in parallel
-        let mut replay_tasks = futures::stream::iter(replay_tasks).buffer_unordered(20);
-        while let Some((table_id, ret)) = replay_tasks.next().await {
-            if let Some(Err(e)) = ret {
+                scope.spawn(async move {
+                    let _permit = semaphore.acquire().await.unwrap();
+                    // Some tables may have been moved to other shards or dropped, ignore such logs.
+                    if let Some(ctx) = serial_exec_ctxs.get(&table_batch.table_id) {
+                        let mut ctx = ctx.lock().await;
+                        let table_data = ctx.table_data.clone();
+                        let result = replay_table_log_entries(
+                            &context.flusher,
+                            context.max_retry_flush_limit,
+                            &mut ctx.serial_exec,
+                            &table_data,
+                            log_entries.into_iter(),
+                        )
+                        .await;
+                        (table_batch.table_id, Some(result))
+                    } else {
+                        (table_batch.table_id, None)
+                    }
+                });
+            }
+        });
+
+        for result in results.into_iter().flatten() {
+            if let (table_id, Some(Err(e))) = result {
                 // If occur error, mark this table as failed and store the cause.
                 failed_tables.insert(table_id, e);
             }


### PR DESCRIPTION
## Rationale
Currently, the WAL replayer uses coroutines to replay the WAL logs of multiple tables in parallel. However, coroutines utilize at most one CPU. By switching to a multithreaded approach, we can fully leverage multiple CPUs.

## Detailed Changes
1. Add dependency [async-scoped](https://docs.rs/async-scoped/latest/async_scoped/).
2. Modify both `TableBasedReplay` and `RegionBasedReplay` to use the `spawn task` approach for parallelism, with a maximum of 20 tasks running concurrently.

## Test Plan
Manual testing.