### PR TITLE
chore: support type `test`, `build` and `style` in pr title

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /^(feat|fix|docs|refactor|chore)(\(.+\))?!?: .+$/; 
+            const regex = /^(feat|fix|docs|refactor|chore|test|style|build)(\(.+\))?!?: .+$/; 
             if (!regex.test(title)) {
               core.setFailed('PR title does not follow the convention, the pattern: ^(feat|fix|docs|refactor|chore)(\(.+\))?!?: .+$');
             }


### PR DESCRIPTION
## Rationale
Close #1575 

## Detailed Changes
Update the check-pr-title pattern to include type `test`, `style` and `build`.

## Test Plan
No need.