### PR TITLE
refactor: make writing properties independently

### DIFF
--- a/horaedb/metric_engine/src/storage.rs
+++ b/horaedb/metric_engine/src/storage.rs
@@ -216,14 +216,20 @@ impl CloudObjectStorage {
             Some(column_options) => {
                 for (col_name, col_opt) in column_options {
                     let col_path = ColumnPath::new(vec![col_name.to_string()]);
-                    builder = builder
-                        .set_column_dictionary_enabled(col_path.clone(), col_opt.enable_dict)
-                        .set_column_bloom_filter_enabled(
-                            col_path.clone(),
-                            col_opt.enable_bloom_filter,
-                        )
-                        .set_column_encoding(col_path.clone(), col_opt.encoding)
-                        .set_column_compression(col_path, col_opt.compression);
+                    if let Some(enable_dict) = col_opt.enable_dict {
+                        builder =
+                            builder.set_column_dictionary_enabled(col_path.clone(), enable_dict);
+                    }
+                    if let Some(enable_bloom_filter) = col_opt.enable_bloom_filter {
+                        builder = builder
+                            .set_column_bloom_filter_enabled(col_path.clone(), enable_bloom_filter);
+                    }
+                    if let Some(encoding) = col_opt.encoding {
+                        builder = builder.set_column_encoding(col_path.clone(), encoding);
+                    }
+                    if let Some(compression) = col_opt.compression {
+                        builder = builder.set_column_compression(col_path, compression);
+                    }
                 }
                 builder
             }

--- a/horaedb/metric_engine/src/storage.rs
+++ b/horaedb/metric_engine/src/storage.rs
@@ -212,29 +212,26 @@ impl CloudObjectStorage {
             .set_encoding(write_options.encoding)
             .set_compression(write_options.compression);
 
-        let builder = match write_options.column_options {
-            Some(column_options) => {
-                for (col_name, col_opt) in column_options {
-                    let col_path = ColumnPath::new(vec![col_name.to_string()]);
-                    if let Some(enable_dict) = col_opt.enable_dict {
-                        builder =
-                            builder.set_column_dictionary_enabled(col_path.clone(), enable_dict);
-                    }
-                    if let Some(enable_bloom_filter) = col_opt.enable_bloom_filter {
-                        builder = builder
-                            .set_column_bloom_filter_enabled(col_path.clone(), enable_bloom_filter);
-                    }
-                    if let Some(encoding) = col_opt.encoding {
-                        builder = builder.set_column_encoding(col_path.clone(), encoding);
-                    }
-                    if let Some(compression) = col_opt.compression {
-                        builder = builder.set_column_compression(col_path, compression);
-                    }
-                }
-                builder
+        if write_options.column_options.is_none() {
+            return builder.build();
+        }
+
+        for (col_name, col_opt) in write_options.column_options.unwrap() {
+            let col_path = ColumnPath::new(vec![col_name.to_string()]);
+            if let Some(enable_dict) = col_opt.enable_dict {
+                builder = builder.set_column_dictionary_enabled(col_path.clone(), enable_dict);
             }
-            None => builder,
-        };
+            if let Some(enable_bloom_filter) = col_opt.enable_bloom_filter {
+                builder =
+                    builder.set_column_bloom_filter_enabled(col_path.clone(), enable_bloom_filter);
+            }
+            if let Some(encoding) = col_opt.encoding {
+                builder = builder.set_column_encoding(col_path.clone(), encoding);
+            }
+            if let Some(compression) = col_opt.compression {
+                builder = builder.set_column_compression(col_path, compression);
+            }
+        }
 
         builder.build()
     }

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -16,11 +16,13 @@
 // under the License.
 
 use std::{
+    collections::HashMap,
     ops::{Add, Deref, Range},
     sync::Arc,
 };
 
 use object_store::ObjectStore;
+use parquet::basic::Compression;
 
 use crate::sst::FileId;
 
@@ -94,4 +96,14 @@ pub type ObjectStoreRef = Arc<dyn ObjectStore>;
 pub struct WriteResult {
     pub id: FileId,
     pub size: usize,
+}
+
+pub struct ColumnOptions {
+    pub enable_dict: bool,
+}
+
+pub struct WriteOptions {
+    pub num_rows_per_row_group: usize,
+    pub compression: Compression,
+    pub column_options: HashMap<String, ColumnOptions>,
 }

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -99,10 +99,10 @@ pub struct WriteResult {
 }
 
 pub struct ColumnOptions {
-    pub enable_dict: bool,
-    pub enable_bloom_filter: bool,
-    pub encoding: Encoding,
-    pub compression: Compression,
+    pub enable_dict: Option<bool>,
+    pub enable_bloom_filter: Option<bool>,
+    pub encoding: Option<Encoding>,
+    pub compression: Option<Compression>,
 }
 
 pub struct WriteOptions {

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -22,17 +22,9 @@ use std::{
 };
 
 use object_store::ObjectStore;
-use parquet::basic::{Compression, Encoding};
+use parquet::basic::{Compression, Encoding, ZstdLevel};
 
 use crate::sst::FileId;
-
-const DEFAULT_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
-const DEFAULT_WRITE_BATCH_SIZE: usize = 1024;
-const DEFAULT_ENABLE_SORTING_COLUMNS: bool = true;
-const DEFAULT_ENABLE_DICT: bool = false;
-const DEFAULT_ENABLE_BLOOM_FILTER: bool = false;
-const DEFAULT_ENCODING: Encoding = Encoding::PLAIN;
-const DEFAULT_COMPRESSION: Compression = Compression::UNCOMPRESSED;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp(pub i64);
@@ -123,20 +115,20 @@ pub struct WriteOptions {
     pub encoding: Encoding,
     pub compression: Compression,
     // use to set column props with column name
-    pub column_options: HashMap<String, ColumnOptions>,
+    pub column_options: Option<HashMap<String, ColumnOptions>>,
 }
 
 impl Default for WriteOptions {
     fn default() -> Self {
         Self {
-            max_row_group_size: DEFAULT_MAX_ROW_GROUP_SIZE,
-            write_bacth_size: DEFAULT_WRITE_BATCH_SIZE,
-            enable_sorting_columns: DEFAULT_ENABLE_SORTING_COLUMNS,
-            enable_dict: DEFAULT_ENABLE_DICT,
-            enable_bloom_filter: DEFAULT_ENABLE_BLOOM_FILTER,
-            encoding: DEFAULT_ENCODING,
-            compression: DEFAULT_COMPRESSION,
-            column_options: HashMap::default(),
+            max_row_group_size: 8192,
+            write_bacth_size: 1024,
+            enable_sorting_columns: true,
+            enable_dict: false,
+            enable_bloom_filter: false,
+            encoding: Encoding::PLAIN,
+            compression: Compression::ZSTD(ZstdLevel::default()),
+            column_options: None,
         }
     }
 }

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -22,9 +22,17 @@ use std::{
 };
 
 use object_store::ObjectStore;
-use parquet::basic::Compression;
+use parquet::basic::{Compression, Encoding};
 
 use crate::sst::FileId;
+
+const DEFAULT_MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
+const DEFAULT_WRITE_BATCH_SIZE: usize = 1024;
+const DEFAULT_ENABLE_SORTING_COLUMNS: bool = true;
+const DEFAULT_ENABLE_DICT: bool = false;
+const DEFAULT_ENABLE_BLOOM_FILTER: bool = false;
+const DEFAULT_ENCODING: Encoding = Encoding::PLAIN;
+const DEFAULT_COMPRESSION: Compression = Compression::UNCOMPRESSED;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp(pub i64);
@@ -100,10 +108,35 @@ pub struct WriteResult {
 
 pub struct ColumnOptions {
     pub enable_dict: bool,
+    pub enable_bloom_filter: bool,
+    pub encoding: Encoding,
+    pub compression: Compression,
 }
 
 pub struct WriteOptions {
-    pub num_rows_per_row_group: usize,
+    pub max_row_group_size: usize,
+    pub write_bacth_size: usize,
+    pub enable_sorting_columns: bool,
+    // use to set column props with default value
+    pub enable_dict: bool,
+    pub enable_bloom_filter: bool,
+    pub encoding: Encoding,
     pub compression: Compression,
+    // use to set column props with column name
     pub column_options: HashMap<String, ColumnOptions>,
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        Self {
+            max_row_group_size: DEFAULT_MAX_ROW_GROUP_SIZE,
+            write_bacth_size: DEFAULT_WRITE_BATCH_SIZE,
+            enable_sorting_columns: DEFAULT_ENABLE_SORTING_COLUMNS,
+            enable_dict: DEFAULT_ENABLE_DICT,
+            enable_bloom_filter: DEFAULT_ENABLE_BLOOM_FILTER,
+            encoding: DEFAULT_ENCODING,
+            compression: DEFAULT_COMPRESSION,
+            column_options: HashMap::default(),
+        }
+    }
 }


### PR DESCRIPTION
## Rationale
We should custom how parquet write handle its metadata.

## Detailed Changes


## Test Plan
