### PR TITLE
feat: add merge stream

### DIFF
--- a/horaedb/Cargo.lock
+++ b/horaedb/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "parquet",
  "pb_types",
  "prost",
+ "temp-dir",
  "thiserror",
  "tokio",
 ]
@@ -2294,6 +2295,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
 
 [[package]]
 name = "tempfile"

--- a/horaedb/Cargo.lock
+++ b/horaedb/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8053b4cedc24eb158e4c041b38cfa0677ef5f4a7ccaa31ee5dcad61dd7aa54"
+checksum = "cbba0799cf6913b456ed07a94f0f3b6e12c62a5d88b10809e2284a0f2b915c05"
 dependencies = [
  "ahash",
  "arrow",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d95efedb3a32f6f74df5bb8fda7b69fb9babe80e92137f25de6ddb15e8e8801"
+checksum = "7493c5c2d40eec435b13d92e5703554f4efc7059451fcb8d3a79580ff0e45560"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d766e0d3dec01a0ab70b1b31678c286cddc0bd7afc9bd82504a1d9a70a7d94"
+checksum = "24953049ebbd6f8964f91f60aa3514e121b5e81e068e33b60e77815ab369b25c"
 dependencies = [
  "ahash",
  "arrow",
@@ -733,6 +733,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown",
+ "indexmap",
  "instant",
  "libc",
  "num_cpus",
@@ -745,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e55db6df319f9e7cf366d0d4ffae793c863823421b2f2b7314a0fefd8e8c11a"
+checksum = "f06df4ef76872e11c924d3c814fd2a8dd09905ed2e2195f71c857d78abd19685"
 dependencies = [
  "log",
  "tokio",
@@ -755,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0c6dc013f955c382438a78fa3de8b0a8bf7b1a4cda5bc46335fe445ff3ff1a"
+checksum = "6bbdcb628d690f3ce5fea7de81642b514486d58ff9779a51f180a69a4eadb361"
 dependencies = [
  "arrow",
  "chrono",
@@ -776,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31405c0bb854451d755b224d41dc466a8f7fd36f8c041c29d2d8432bd0c08c"
+checksum = "8036495980e3131f706b7d33ab00b4492d73dc714e3cb74d11b50f9602a73246"
 dependencies = [
  "ahash",
  "arrow",
@@ -788,7 +789,9 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
+ "indexmap",
  "paste",
  "serde_json",
  "sqlparser",
@@ -798,20 +801,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc8266b6627c8264c87bc7c82564e3d89ed5f0f9943b49a30dac1f1ac12e4c0"
+checksum = "4da0f3cb4669f9523b403d6b5a0ec85023e0ab3bf0183afd1517475b3e64fdd2"
 dependencies = [
  "arrow",
  "datafusion-common",
+ "itertools 0.13.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5712668780bc43666ecd10acd188b7df58e2a5501d4dbbd972bf209f1790138b"
+checksum = "f52c4012648b34853e40a2c6bcaa8772f837831019b68aca384fb38436dba162"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -836,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec138af6b7482fb726f1bfeec010fc063b9614594c36a1051a4d3b365ba6a5f"
+checksum = "e5b8bb624597ba28ed7446df4a9bd7c7a7bde7c578b6b527da3f47371d5f6741"
 dependencies = [
  "ahash",
  "arrow",
@@ -850,16 +854,16 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
+ "indexmap",
  "log",
  "paste",
- "sqlparser",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564499c6bdd3ab9f76c7ad727e858bc6791e4de6c1a484d21d2bf49daaa658d6"
+checksum = "6fb06208fc470bc8cf1ce2d9a1159d42db591f2c7264a8c1776b53ad8f675143"
 dependencies = [
  "ahash",
  "arrow",
@@ -871,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b55ea2221ae1c1e37d524f8330f763dcdc205edb74fe5f54cbdea475c17fd18"
+checksum = "fca25bbb87323716d05e54114666e942172ccca23c5a507e9c7851db6e965317"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -894,21 +898,34 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6932996c4407ee1ebf23ffd706e982729cb9b6f7a31a281abac51fe524c3a049"
+checksum = "5ae23356c634e54c59f7c51acb7a5b9f6240ffb2cf997049a1a24a8a88598dbe"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b3d6ff7794acea026de36007077a06b18b89e4f9c3fea7f2215f9f7dd9059b"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8afa1eb44e2f00cc8d82b88803e456a681474b8877ceecc04e9517d5c843c"
+checksum = "bec6241eb80c595fa0e1a8a6b69686b5cf3bd5fdacb8319582a0943b0bd788aa"
 dependencies = [
  "arrow",
  "async-trait",
@@ -926,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570666d84df483473626fab4e69997d048b40d0e7c67c540299714f244d99e73"
+checksum = "3370357b8fc75ec38577700644e5d1b0bc78f38babab99c0b8bd26bafb3e4335"
 dependencies = [
  "ahash",
  "arrow",
@@ -937,30 +954,26 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-string",
- "base64",
  "chrono",
  "datafusion-common",
- "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown",
- "hex",
  "indexmap",
  "itertools 0.13.0",
  "log",
  "paste",
  "petgraph",
- "regex",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3746cbdfb32d67399dcaad17042e419ac6da454a7e38ff098aa2fbf0a7388982"
+checksum = "b8b7734d94bf2fa6f6e570935b0ddddd8421179ce200065be97874e13d46a47b"
 dependencies = [
  "ahash",
  "arrow",
@@ -972,13 +985,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696f06e79d44f7c50f57cea23493881d86d9d9647884d38ce467c7f75c13e286"
+checksum = "7eee8c479522df21d7b395640dff88c5ed05361852dce6544d7c98e9dbcebffe"
 dependencies = [
+ "arrow",
  "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "itertools 0.13.0",
@@ -986,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e1d084224023e09cdea14d01ded0f2092c319c7b4594ebc821283b9c7c4a35"
+checksum = "17e1fc2e2c239d14e8556f2622b19a726bf6bc6962cc00c71fc52626274bee24"
 dependencies = [
  "ahash",
  "arrow",
@@ -1002,8 +1017,8 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
@@ -1021,15 +1036,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "42.1.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c105148357dcbd9e4c97eada2930a59f7923215461d9f47de6e76edd60eab2d5"
+checksum = "63e3a4ed41dbee20a5d947a59ca035c225d67dc9cbe869c10f66dcdf25e7ce51"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
+ "indexmap",
  "log",
  "regex",
  "sqlparser",
@@ -1751,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.1.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310c46a70a3ba90d98fec39fa2da6d9d731e544191da6fb56c9d199484d0dd3e"
+checksum = "dea02606ba6f5e856561d8d507dba8bac060aefca2a6c0f1aa1d361fed91ff3e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2232,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
+checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
 dependencies = [
  "log",
  "sqlparser_derive",

--- a/horaedb/Cargo.lock
+++ b/horaedb/Cargo.lock
@@ -1554,6 +1554,7 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "datafusion",

--- a/horaedb/Cargo.toml
+++ b/horaedb/Cargo.toml
@@ -37,6 +37,7 @@ macros = { path = "../src/components/macros" }
 pb_types = { path = "pb_types" }
 prost = { version = "0.13" }
 arrow = { version = "53", features = ["prettyprint"] }
+arrow-schema = "53"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 async-stream = "0.3"

--- a/horaedb/Cargo.toml
+++ b/horaedb/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = { version = "1.0" }
 metric_engine = { path = "metric_engine" }
 thiserror = "1"
 bytes = "1"
-datafusion = "42"
+datafusion = "43"
 parquet = { version = "53" }
 object_store = { version = "0.11" }
 macros = { path = "../src/components/macros" }

--- a/horaedb/Cargo.toml
+++ b/horaedb/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 async-stream = "0.3"
 futures = "0.3"
+temp-dir = "0.1"
 itertools = "0.3"
 lazy_static = "1"
 tracing = "0.1"

--- a/horaedb/metric_engine/Cargo.toml
+++ b/horaedb/metric_engine/Cargo.toml
@@ -33,6 +33,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arrow = { workspace = true }
+arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 datafusion = { workspace = true }

--- a/horaedb/metric_engine/Cargo.toml
+++ b/horaedb/metric_engine/Cargo.toml
@@ -46,3 +46,6 @@ pb_types = { workspace = true }
 prost = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+temp-dir = { workspace = true }

--- a/horaedb/metric_engine/src/lib.rs
+++ b/horaedb/metric_engine/src/lib.rs
@@ -17,6 +17,7 @@
 
 //! Storage Engine for metrics.
 
+#![feature(duration_constructors)]
 pub mod error;
 mod manifest;
 mod read;

--- a/horaedb/metric_engine/src/macros.rs
+++ b/horaedb/metric_engine/src/macros.rs
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Storage Engine for metrics.
-
-#![feature(duration_constructors)]
-pub mod error;
-mod macros;
-mod manifest;
-mod read;
-mod sst;
-pub mod storage;
-mod test_util;
-pub mod types;
-
-pub use error::{AnyhowError, Error, Result};
+#[macro_export]
+macro_rules! compare_primitive_columns {
+    ($lhs_col:expr, $rhs_col:expr, $lhs_idx:expr, $rhs_idx:expr, $($type:ty),+) => {
+        $(
+            if let Some(lhs_col) = $lhs_col.as_primitive_opt::<$type>() {
+                let rhs_col = $rhs_col.as_primitive::<$type>();
+                if !lhs_col.value($lhs_idx).eq(&rhs_col.value($rhs_idx)) {
+                    return false;
+                }
+            }
+        )+
+    };
+}

--- a/horaedb/metric_engine/src/read.rs
+++ b/horaedb/metric_engine/src/read.rs
@@ -15,16 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{any::Any, sync::Arc};
+use std::{
+    any::Any,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
+use arrow::{
+    array::{AsArray, BinaryArray, PrimitiveArray, RecordBatch},
+    compute::concat_batches,
+    datatypes::{GenericBinaryType, Int8Type, UInt64Type, UInt8Type},
+};
+use arrow_schema::SchemaRef;
 use datafusion::{
+    common::internal_err,
     datasource::physical_plan::{FileMeta, ParquetFileReaderFactory},
-    error::Result as DfResult,
-    execution::{SendableRecordBatchStream, TaskContext},
+    error::{DataFusionError, Result as DfResult},
+    execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext},
     logical_expr::AggregateUDFImpl,
     parquet::arrow::async_reader::AsyncFileReader,
-    physical_plan::{metrics::ExecutionPlanMetricsSet, DisplayAs, ExecutionPlan, PlanProperties},
+    physical_plan::{
+        metrics::ExecutionPlanMetricsSet, DisplayAs, Distribution, ExecutionPlan, PlanProperties,
+    },
 };
+use futures::{ready, Stream, StreamExt};
 use parquet::arrow::async_reader::ParquetObjectReader;
 
 use crate::types::ObjectStoreRef;
@@ -64,21 +79,46 @@ impl ParquetFileReaderFactory for DefaultParquetFileReaderFactory {
 /// column.
 #[derive(Debug)]
 struct MergeExec {
-    num_primary_keys: usize,
-    seq_idx: usize,
-    // (idx, merge_op)
-    values: Vec<(usize, Arc<dyn AggregateUDFImpl>)>,
     /// Input plan
     input: Arc<dyn ExecutionPlan>,
+    /// (0..num_primary_keys) are primary key columns
+    num_primary_keys: usize,
+    /// Sequence column index
+    seq_idx: usize,
+    // (idx, merge_op)
+    value_idx: usize,
+    value_op: Arc<dyn AggregateUDFImpl>,
 }
 
+impl MergeExec {
+    fn new(
+        input: Arc<dyn ExecutionPlan>,
+        num_primary_keys: usize,
+        seq_idx: usize,
+        value_idx: usize,
+        value_op: Arc<dyn AggregateUDFImpl>,
+    ) -> Self {
+        Self {
+            input,
+            num_primary_keys,
+            seq_idx,
+            value_idx,
+            value_op,
+        }
+    }
+}
 impl DisplayAs for MergeExec {
     fn fmt_as(
         &self,
-        t: datafusion::physical_plan::DisplayFormatType,
+        _t: datafusion::physical_plan::DisplayFormatType,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
-        todo!()
+        write!(
+            f,
+            "MergeExec: [primary_keys: {}, seq_idx: {}]",
+            self.num_primary_keys, self.seq_idx
+        )?;
+        Ok(())
     }
 }
 
@@ -92,7 +132,11 @@ impl ExecutionPlan for MergeExec {
     }
 
     fn properties(&self) -> &PlanProperties {
-        todo!()
+        self.input.properties()
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition; self.children().len()]
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -100,14 +144,20 @@ impl ExecutionPlan for MergeExec {
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {
-        vec![true]
+        vec![true; self.children().len()]
     }
 
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
-        todo!()
+        Ok(Arc::new(MergeExec::new(
+            Arc::clone(&children[0]),
+            self.num_primary_keys,
+            self.seq_idx,
+            self.value_idx,
+            self.value_op.clone(),
+        )))
     }
 
     fn execute(
@@ -115,6 +165,128 @@ impl ExecutionPlan for MergeExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DfResult<SendableRecordBatchStream> {
+        if 0 != partition {
+            return internal_err!("MergeExec invalid partition {partition}");
+        }
+
+        Ok(Box::pin(MergeStream::new(
+            self.input.execute(partition, context)?,
+            self.num_primary_keys,
+            self.seq_idx,
+            self.value_idx,
+            self.value_op.clone(),
+        )))
+    }
+}
+
+struct MergeStream {
+    stream: SendableRecordBatchStream,
+    num_primary_keys: usize,
+    seq_idx: usize,
+    value_idx: usize,
+    value_op: Arc<dyn AggregateUDFImpl>,
+
+    pending_batch: Option<RecordBatch>,
+}
+
+impl MergeStream {
+    fn new(
+        stream: SendableRecordBatchStream,
+        num_primary_keys: usize,
+        seq_idx: usize,
+        value_idx: usize,
+        value_op: Arc<dyn AggregateUDFImpl>,
+    ) -> Self {
+        Self {
+            stream,
+            num_primary_keys,
+            seq_idx,
+            value_idx,
+            value_op,
+            pending_batch: None,
+        }
+    }
+
+    fn primary_key_eq2(
+        &self,
+        lhs: &RecordBatch,
+        lhs_idx: usize,
+        rhs: &RecordBatch,
+        rhs_idx: usize,
+    ) -> bool {
+        for k in 0..self.num_primary_keys {
+            let lhs_col = lhs.column(k);
+            let rhs_col = rhs.column(k);
+            if let Some(lhs_col) = lhs_col.as_primitive_opt::<UInt8Type>() {
+                let rhs_col = rhs_col.as_primitive::<UInt8Type>();
+                if !lhs_col.value(lhs_idx).eq(&rhs_col.value(rhs_idx)) {
+                    return false;
+                }
+            } else if let Some(lhs_col) = lhs_col.as_primitive_opt::<UInt64Type>() {
+                let rhs_col = rhs_col.as_primitive::<UInt64Type>();
+                if !lhs_col.value(lhs_idx).eq(&rhs_col.value(rhs_idx)) {
+                    return false;
+                }
+            } else if let Some(lhs_col) = lhs_col.as_bytes_opt::<GenericBinaryType<i32>>() {
+                let rhs_col = rhs_col.as_bytes::<GenericBinaryType<i32>>();
+                if !rhs_col.value(rhs_idx).eq(lhs_col.value(lhs_idx)) {
+                    return false;
+                }
+            } else {
+                unreachable!("unsupported column type: {:?}", lhs_col.data_type())
+            }
+        }
+
+        true
+    }
+
+    fn primary_key_eq(&self, batch: &RecordBatch, i: usize, j: usize) -> bool {
+        self.primary_key_eq2(batch, i, batch, j)
+    }
+
+    // TODO: only support deduplication now, merge operation will be added later.
+    fn merge_batch(&mut self, batch: RecordBatch) -> DfResult<RecordBatch> {
+        let mut row_idx = 0;
+        let mut batches = vec![];
+        while row_idx < batch.num_rows() {
+            let mut cursor = row_idx + 1;
+            while self.primary_key_eq(&batch, row_idx, cursor) {
+                cursor += 1;
+            }
+
+            let same_pk_batch = batch.slice(row_idx, cursor - row_idx);
+            if let Some(pending) = self.pending_batch.take() {
+                if !self.primary_key_eq2(&pending, pending.num_rows() - 1, &same_pk_batch, 0) {
+                    // only keep the last row in this batch
+                    batches.push(pending.slice(pending.num_rows() - 1, 1));
+                }
+            }
+            batches.push(same_pk_batch.slice(same_pk_batch.num_rows() - 1, 1));
+
+            row_idx = cursor;
+        }
+        self.pending_batch = batches.pop();
+
+        concat_batches(&self.stream.schema(), batches.iter().map(|v| v))
+            .map_err(|e| DataFusionError::ArrowError(e, None))
+    }
+}
+
+impl Stream for MergeStream {
+    type Item = DfResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
+        Poll::Ready(ready!(self.stream.poll_next_unpin(ctx)).map(|r| {
+            r.and_then(|batch| {
+                let batch = self.merge_batch(batch)?;
+                Ok(batch)
+            })
+        }))
+    }
+}
+
+impl RecordBatchStream for MergeStream {
+    fn schema(&self) -> SchemaRef {
         todo!()
     }
 }

--- a/horaedb/metric_engine/src/read.rs
+++ b/horaedb/metric_engine/src/read.rs
@@ -306,7 +306,7 @@ impl Stream for MergeStream {
     type Item = DfResult<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
-        match dbg!(self.stream.poll_next_unpin(ctx)) {
+        match self.stream.poll_next_unpin(ctx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => {
                 let value = if let Some(mut pending) = self.pending_batch.take() {

--- a/horaedb/metric_engine/src/storage.rs
+++ b/horaedb/metric_engine/src/storage.rs
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "Depend on MergeExec"]
+    // #[ignore = "Depend on MergeExec"]
     async fn test_storage_write_and_scan() {
         let schema = arrow_schema!(("pk1", UInt8), ("pk2", UInt8), ("value", Int64));
         let root_dir = temp_dir::TempDir::new().unwrap();

--- a/horaedb/metric_engine/src/storage.rs
+++ b/horaedb/metric_engine/src/storage.rs
@@ -323,7 +323,7 @@ impl CloudObjectStorage {
             Arc::new(sort_exec),
             self.num_primary_keys,
             self.schema().fields.len() - 1,
-            0, // TODO: value_idx
+            0, // TODO: value_idx, not used now.
             Arc::new(LastValue::new()),
         );
         Ok(Arc::new(merge_exec))

--- a/horaedb/metric_engine/src/storage.rs
+++ b/horaedb/metric_engine/src/storage.rs
@@ -51,7 +51,7 @@ use parquet::{
 
 use crate::{
     manifest::Manifest,
-    read::DefaultParquetFileReaderFactory,
+    read::{DefaultParquetFileReaderFactory, HoraedbSchemaAdapterFactory},
     sst::{allocate_id, FileId, FileMeta, SstFile},
     types::{ObjectStoreRef, TimeRange, WriteOptions, WriteResult},
     Result,
@@ -271,9 +271,11 @@ impl CloudObjectStorage {
             .with_file_groups(file_groups)
             .with_projection(projections);
 
-        let mut builder = ParquetExec::builder(scan_config).with_parquet_file_reader_factory(
-            Arc::new(DefaultParquetFileReaderFactory::new(self.store.clone())),
-        );
+        let mut builder = ParquetExec::builder(scan_config)
+            .with_schema_adapter_factory(Arc::new(HoraedbSchemaAdapterFactory { seq: todo!() }))
+            .with_parquet_file_reader_factory(Arc::new(DefaultParquetFileReaderFactory::new(
+                self.store.clone(),
+            )));
         if let Some(expr) = conjunction(predicates) {
             let filters = create_physical_expr(&expr, &self.df_schema, &ExecutionProps::new())
                 .context("create pyhsical expr")?;

--- a/horaedb/metric_engine/src/test_util.rs
+++ b/horaedb/metric_engine/src/test_util.rs
@@ -15,15 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Storage Engine for metrics.
+#[macro_export]
+macro_rules! arrow_schema {
+    ($(($field_name:expr, $data_type:ident)),* $(,)?) => {{
+        let fields = vec![
+            $(
+                arrow::datatypes::Field::new($field_name, arrow::datatypes::DataType::$data_type, true),
+            )*
+        ];
+        std::sync::Arc::new(arrow::datatypes::Schema::new(fields))
+    }};
+}
 
-#![feature(duration_constructors)]
-pub mod error;
-mod manifest;
-mod read;
-mod sst;
-pub mod storage;
-mod test_util;
-pub mod types;
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_arrow_schema_macro() {
+        let schema = arrow_schema![("a", UInt8), ("b", UInt8), ("c", UInt8), ("d", UInt8),];
 
-pub use error::{AnyhowError, Error, Result};
+        let expected_names = ["a", "b", "c", "d"];
+        for (i, f) in schema.fields().iter().enumerate() {
+            assert_eq!(f.name(), expected_names[i]);
+        }
+    }
+}

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -26,6 +26,10 @@ use parquet::basic::{Compression, Encoding, ZstdLevel};
 
 use crate::sst::FileId;
 
+// Seq column is a builtin column, and it will be appended to the end of
+// user-defined schema.
+pub const SEQ_COLUMN_NAME: &str = "__seq__";
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp(pub i64);
 

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -104,6 +104,7 @@ pub type ObjectStoreRef = Arc<dyn ObjectStore>;
 
 pub struct WriteResult {
     pub id: FileId,
+    pub seq: u64,
     pub size: usize,
 }
 

--- a/horaedb/metric_engine/src/types.rs
+++ b/horaedb/metric_engine/src/types.rs
@@ -73,6 +73,15 @@ impl From<Range<Timestamp>> for TimeRange {
     }
 }
 
+impl From<Range<i64>> for TimeRange {
+    fn from(value: Range<i64>) -> Self {
+        Self(Range {
+            start: value.start.into(),
+            end: value.end.into(),
+        })
+    }
+}
+
 impl Deref for TimeRange {
     type Target = Range<Timestamp>;
 


### PR DESCRIPTION
## Rationale

Part of Metric Engine.

## Detailed Changes
- Scan SSTs in parallel based on segment
- Sort SST using SortPreservingMergeExec, which is more efficient than SortExec
- Add MergeExec to dedup record batch based on sorted batches, currently only `overwrite` semantics is supported.

## Test Plan

Add two new UT.