### PR TITLE
fix: manifest delta num may overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,7 +3194,9 @@ checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -3375,6 +3386,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ dependencies = [
  "parquet",
  "pb_types",
  "prost",
+ "serde",
  "temp-dir",
  "test-log",
  "thiserror",

--- a/docs/example.toml
+++ b/docs/example.toml
@@ -22,9 +22,10 @@ enable_write = true
 write_worker_num = 1
 write_interval = "500ms"
 
-[metric_engine.storage]
+[metric_engine.threads]
+sst_thread_num = 2
+manifest_thread_num = 2
+
+[metric_engine.storage.object_store]
 type = "Local"
 data_dir = "/tmp/horaedb-storage"
-
-[metric_engine.sst]
-background_thread_num = 2

--- a/docs/example.toml
+++ b/docs/example.toml
@@ -19,7 +19,12 @@ port = 5000
 
 [test]
 enable_write = true
+write_worker_num = 1
+write_interval = "500ms"
 
 [metric_engine.storage]
 type = "Local"
 data_dir = "/tmp/horaedb-storage"
+
+[metric_engine.sst]
+background_thread_num = 2

--- a/docs/example.toml
+++ b/docs/example.toml
@@ -17,7 +17,8 @@
 
 port = 5000
 
-[metric_engine]
+[test]
+enable_write = true
 
 [metric_engine.storage]
 type = "Local"

--- a/src/benchmarks/src/encoding_bench.rs
+++ b/src/benchmarks/src/encoding_bench.rs
@@ -19,7 +19,7 @@
 
 use bytes::Bytes;
 use metric_engine::{
-    manifest::{ManifestUpdate, Snapshot},
+    manifest::Snapshot,
     sst::{FileMeta, SstFile},
 };
 
@@ -43,11 +43,7 @@ impl EncodingBench {
         );
         let sstfiles = vec![sstfile.clone(); config.record_count];
         let mut snapshot = Snapshot::try_from(Bytes::new()).unwrap();
-        let update = ManifestUpdate {
-            to_adds: sstfiles,
-            to_deletes: vec![],
-        };
-        let _ = snapshot.merge_update(update);
+        snapshot.add_records(sstfiles);
 
         EncodingBench {
             raw_bytes: snapshot.into_bytes().unwrap(),
@@ -60,11 +56,7 @@ impl EncodingBench {
         // first decode snapshot and then append with delta sstfiles, serialize to bytes
         // at last
         let mut snapshot = Snapshot::try_from(self.raw_bytes.clone()).unwrap();
-        let update = ManifestUpdate {
-            to_adds: self.to_append.clone(),
-            to_deletes: vec![],
-        };
-        let _ = snapshot.merge_update(update);
+        snapshot.add_records(self.to_append.clone());
         let _ = snapshot.into_bytes();
     }
 }

--- a/src/metric_engine/Cargo.toml
+++ b/src/metric_engine/Cargo.toml
@@ -48,6 +48,7 @@ object_store = { workspace = true }
 parquet = { workspace = true, features = ["object_store"] }
 pb_types = { workspace = true }
 prost = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/src/metric_engine/src/compaction/mod.rs
+++ b/src/metric_engine/src/compaction/mod.rs
@@ -19,7 +19,7 @@ mod executor;
 mod picker;
 mod scheduler;
 
-pub use scheduler::{Scheduler as CompactionScheduler, SchedulerConfig};
+pub use scheduler::Scheduler as CompactionScheduler;
 
 use crate::sst::SstFile;
 

--- a/src/metric_engine/src/compaction/picker.rs
+++ b/src/metric_engine/src/compaction/picker.rs
@@ -51,8 +51,8 @@ impl Picker {
 
     /// This function picks a candidate for compaction.
     /// Note: It can only execute sequentially, otherwise a SST may be picked by
-    /// multiple threads.
-    pub async fn pick_candidate(&self) -> Option<Task> {
+    /// multiple threads(that's why it take a mutable self).
+    pub async fn pick_candidate(&mut self) -> Option<Task> {
         let ssts = self.manifest.all_ssts().await;
         let expire_time = self.ttl.map(|ttl| (now() - ttl.as_micros() as i64).into());
         self.strategy.pick_candidate(ssts, expire_time)

--- a/src/metric_engine/src/compaction/scheduler.rs
+++ b/src/metric_engine/src/compaction/scheduler.rs
@@ -63,6 +63,7 @@ impl Scheduler {
             let store = store.clone();
             let manifest = manifest.clone();
             let write_props = config.write_props.clone();
+            let trigger_tx = trigger_tx.clone();
             let executor = Executor::new(
                 runtime.clone(),
                 store,
@@ -72,6 +73,7 @@ impl Scheduler {
                 parquet_reader,
                 write_props,
                 config.memory_limit,
+                trigger_tx.clone(),
             );
 
             runtime.spawn(async move {
@@ -86,6 +88,7 @@ impl Scheduler {
                     segment_duration,
                     config.new_sst_max_size,
                     config.input_sst_max_num,
+                    config.input_sst_min_num,
                 );
                 Self::generate_task_loop(task_tx, trigger_rx, picker, config.schedule_interval)
                     .await;

--- a/src/metric_engine/src/compaction/scheduler.rs
+++ b/src/metric_engine/src/compaction/scheduler.rs
@@ -109,6 +109,7 @@ impl Scheduler {
     }
 
     async fn recv_task_loop(mut task_rx: Receiver<Task>, executor: Executor) {
+        info!("Scheduler receive task started");
         while let Some(task) = task_rx.recv().await {
             executor.submit(task);
         }
@@ -165,13 +166,13 @@ pub struct SchedulerConfig {
 impl Default for SchedulerConfig {
     fn default() -> Self {
         Self {
-            schedule_interval: Duration::from_secs(30),
+            schedule_interval: Duration::from_secs(5),
             max_pending_compaction_tasks: 10,
-            memory_limit: bytesize::gb(3_u64),
+            memory_limit: bytesize::gb(30_u64),
             write_props: WriterProperties::default(),
             ttl: None,
             new_sst_max_size: bytesize::gb(1_u64),
-            input_sst_max_num: 10,
+            input_sst_max_num: 30,
         }
     }
 }

--- a/src/metric_engine/src/compaction/scheduler.rs
+++ b/src/metric_engine/src/compaction/scheduler.rs
@@ -18,7 +18,6 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
-use parquet::file::properties::WriterProperties;
 use tokio::{
     sync::mpsc::{self, Receiver, Sender},
     task::JoinHandle,
@@ -29,6 +28,7 @@ use tracing::{info, warn};
 use super::{executor::Executor, picker::Picker};
 use crate::{
     compaction::Task,
+    config::SchedulerConfig,
     manifest::ManifestRef,
     read::ParquetReader,
     sst::SstPathGenerator,
@@ -146,33 +146,6 @@ impl Scheduler {
                     }
                 }
             }
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct SchedulerConfig {
-    pub schedule_interval: Duration,
-    pub max_pending_compaction_tasks: usize,
-    // Runner config
-    pub memory_limit: u64,
-    pub write_props: WriterProperties,
-    // Picker config
-    pub ttl: Option<Duration>,
-    pub new_sst_max_size: u64,
-    pub input_sst_max_num: usize,
-}
-
-impl Default for SchedulerConfig {
-    fn default() -> Self {
-        Self {
-            schedule_interval: Duration::from_secs(5),
-            max_pending_compaction_tasks: 10,
-            memory_limit: bytesize::gb(30_u64),
-            write_props: WriterProperties::default(),
-            ttl: None,
-            new_sst_max_size: bytesize::gb(1_u64),
-            input_sst_max_num: 30,
         }
     }
 }

--- a/src/metric_engine/src/config.rs
+++ b/src/metric_engine/src/config.rs
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{collections::HashMap, time::Duration};
+
+use parquet::{
+    basic::{Compression, Encoding, ZstdLevel},
+    file::properties::WriterProperties,
+};
+
+use crate::types::UpdateMode;
+
+#[derive(Clone)]
+pub struct SchedulerConfig {
+    pub schedule_interval: Duration,
+    pub max_pending_compaction_tasks: usize,
+    // Runner config
+    pub memory_limit: u64,
+    pub write_props: WriterProperties,
+    // Picker config
+    pub ttl: Option<Duration>,
+    pub new_sst_max_size: u64,
+    pub input_sst_max_num: usize,
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            schedule_interval: Duration::from_secs(10),
+            max_pending_compaction_tasks: 10,
+            memory_limit: bytesize::gb(3_u64),
+            write_props: WriterProperties::default(),
+            ttl: None,
+            new_sst_max_size: bytesize::gb(1_u64),
+            input_sst_max_num: 30,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ColumnOptions {
+    pub enable_dict: Option<bool>,
+    pub enable_bloom_filter: Option<bool>,
+    pub encoding: Option<Encoding>,
+    pub compression: Option<Compression>,
+}
+
+#[derive(Debug)]
+pub struct WriteOptions {
+    pub max_row_group_size: usize,
+    pub write_bacth_size: usize,
+    pub enable_sorting_columns: bool,
+    // use to set column props with default value
+    pub enable_dict: bool,
+    pub enable_bloom_filter: bool,
+    pub encoding: Encoding,
+    pub compression: Compression,
+    // use to set column props with column name
+    pub column_options: Option<HashMap<String, ColumnOptions>>,
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        Self {
+            max_row_group_size: 8192,
+            write_bacth_size: 1024,
+            enable_sorting_columns: true,
+            enable_dict: false,
+            enable_bloom_filter: false,
+            encoding: Encoding::PLAIN,
+            compression: Compression::ZSTD(ZstdLevel::default()),
+            column_options: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ManifestMergeOptions {
+    pub channel_size: usize,
+    pub merge_interval_seconds: usize,
+    pub min_merge_threshold: usize,
+    pub hard_merge_threshold: usize,
+    pub soft_merge_threshold: usize,
+}
+
+impl Default for ManifestMergeOptions {
+    fn default() -> Self {
+        Self {
+            channel_size: 3,
+            merge_interval_seconds: 5,
+            min_merge_threshold: 10,
+            soft_merge_threshold: 50,
+            hard_merge_threshold: 90,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct StorageOptions {
+    pub write_opts: WriteOptions,
+    pub manifest_merge_opts: ManifestMergeOptions,
+    pub update_mode: UpdateMode,
+}

--- a/src/metric_engine/src/config.rs
+++ b/src/metric_engine/src/config.rs
@@ -35,6 +35,7 @@ pub struct SchedulerConfig {
     pub ttl: Option<Duration>,
     pub new_sst_max_size: u64,
     pub input_sst_max_num: usize,
+    pub input_sst_min_num: usize,
 }
 
 impl Default for SchedulerConfig {
@@ -47,6 +48,7 @@ impl Default for SchedulerConfig {
             ttl: None,
             new_sst_max_size: bytesize::gb(1_u64),
             input_sst_max_num: 30,
+            input_sst_min_num: 5,
         }
     }
 }

--- a/src/metric_engine/src/lib.rs
+++ b/src/metric_engine/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![feature(duration_constructors)]
 mod compaction;
+pub mod config;
 pub mod error;
 mod macros;
 pub mod manifest;

--- a/src/metric_engine/src/manifest/encoding.rs
+++ b/src/metric_engine/src/manifest/encoding.rs
@@ -326,7 +326,7 @@ impl Snapshot {
     }
 
     pub fn into_bytes(self) -> Result<Bytes> {
-        let buf = Vec::with_capacity(self.header.length as usize * SnapshotHeader::LENGTH);
+        let buf = Vec::with_capacity(self.header.length as usize + SnapshotHeader::LENGTH);
         let mut cursor = Cursor::new(buf);
 
         self.header.write_to(&mut cursor)?;

--- a/src/metric_engine/src/manifest/mod.rs
+++ b/src/metric_engine/src/manifest/mod.rs
@@ -39,8 +39,9 @@ use tokio::sync::{
 use tracing::{debug, error, info, trace};
 
 use crate::{
+    config::ManifestMergeOptions,
     sst::{FileId, FileMeta, SstFile},
-    types::{ManifestMergeOptions, ObjectStoreRef, RuntimeRef, TimeRange},
+    types::{ObjectStoreRef, RuntimeRef, TimeRange},
     AnyhowError, Result,
 };
 

--- a/src/metric_engine/src/manifest/mod.rs
+++ b/src/metric_engine/src/manifest/mod.rs
@@ -91,7 +91,11 @@ impl Manifest {
         .await?;
         let snapshot = read_snapshot(&store, &snapshot_path).await?;
         let ssts = snapshot.into_ssts();
-        debug!(sst_len = ssts.len(), "Load manifest snapshot when startup");
+        debug!(
+            sst_len = ssts.len(),
+            first_100 = ?ssts.iter().take(100),
+            "Load manifest snapshot when startup"
+        );
         {
             let merger = merger.clone();
             // Start merger in background

--- a/src/metric_engine/src/manifest/mod.rs
+++ b/src/metric_engine/src/manifest/mod.rs
@@ -35,7 +35,7 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     RwLock,
 };
-use tracing::{error, info, trace};
+use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 use crate::{
@@ -133,7 +133,11 @@ impl Manifest {
             }
             // TODO: sort files in payload, so we can delete files more
             // efficiently.
+            let ids = ssts.iter().map(|f| f.id()).collect::<Vec<_>>();
+            debug!(old_length = ssts.len(), deletes=update.to_deletes.len(),ids=?ids,"before update manifest");
             ssts.retain(|file| !update.to_deletes.contains(&file.id()));
+            let ids = ssts.iter().map(|f| f.id()).collect::<Vec<_>>();
+            debug!(old_length = ssts.len(), ids=?ids,"after update manifest");
         }
 
         Ok(())

--- a/src/metric_engine/src/manifest/mod.rs
+++ b/src/metric_engine/src/manifest/mod.rs
@@ -39,7 +39,7 @@ use tokio::sync::{
 use tracing::{debug, error, info, trace};
 
 use crate::{
-    config::ManifestMergeOptions,
+    config::ManifestConfig,
     sst::{FileId, FileMeta, SstFile},
     types::{ObjectStoreRef, RuntimeRef, TimeRange},
     AnyhowError, Result,
@@ -77,7 +77,7 @@ impl Manifest {
         root_dir: String,
         store: ObjectStoreRef,
         runtime: RuntimeRef,
-        merge_options: ManifestMergeOptions,
+        merge_options: ManifestConfig,
     ) -> Result<Self> {
         let snapshot_path = Path::from(format!("{root_dir}/{PREFIX_PATH}/{SNAPSHOT_FILENAME}"));
         let delta_dir = Path::from(format!("{root_dir}/{PREFIX_PATH}/{DELTA_PREFIX}"));
@@ -188,7 +188,7 @@ struct ManifestMerger {
     sender: Sender<MergeType>,
     receiver: RwLock<Receiver<MergeType>>,
     deltas_num: AtomicUsize,
-    merge_options: ManifestMergeOptions,
+    merge_options: ManifestConfig,
 }
 
 impl ManifestMerger {
@@ -196,7 +196,7 @@ impl ManifestMerger {
         snapshot_path: Path,
         delta_dir: Path,
         store: ObjectStoreRef,
-        merge_options: ManifestMergeOptions,
+        merge_options: ManifestConfig,
     ) -> Result<Arc<Self>> {
         let (tx, rx) = mpsc::channel(merge_options.channel_size);
         let merger = Self {
@@ -414,7 +414,7 @@ mod tests {
                 root_dir.path().to_string_lossy().to_string(),
                 store,
                 runtime.clone(),
-                ManifestMergeOptions::default(),
+                ManifestConfig::default(),
             )
             .await
             .unwrap();
@@ -471,7 +471,7 @@ mod tests {
                 root_dir,
                 store.clone(),
                 runtime.clone(),
-                ManifestMergeOptions {
+                ManifestConfig {
                     merge_interval_seconds: 1,
                     ..Default::default()
                 },

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -54,9 +54,10 @@ use parquet::arrow::async_reader::ParquetObjectReader;
 
 use crate::{
     compare_primitive_columns,
+    config::UpdateMode,
     operator::{BytesMergeOperator, LastValueOperator, MergeOperator, MergeOperatorRef},
     sst::{SstFile, SstPathGenerator},
-    types::{ObjectStoreRef, StorageSchema, UpdateMode, SEQ_COLUMN_NAME},
+    types::{ObjectStoreRef, StorageSchema, SEQ_COLUMN_NAME},
     Result,
 };
 

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -51,7 +51,6 @@ use datafusion::{
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use parquet::arrow::async_reader::ParquetObjectReader;
-use tracing::trace;
 
 use crate::{
     compare_primitive_columns,
@@ -266,8 +265,6 @@ impl MergeStream {
             return Ok(None);
         }
 
-        trace!(pending_batch = ?self.pending_batch, "Merge batch");
-
         // Group rows with the same primary keys
         let mut groupby_pk_batches = Vec::new();
         let mut start_idx = 0;
@@ -280,7 +277,6 @@ impl MergeStream {
             }
             groupby_pk_batches.push(batch.slice(start_idx, end_idx - start_idx));
             start_idx = end_idx;
-            trace!(end_idx, "Group rows with the same primary keys");
         }
 
         let rows_with_same_primary_keys = &groupby_pk_batches[0];

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -426,7 +426,7 @@ impl ParquetReader {
             })
             .collect::<Vec<_>>();
         let scan_config = FileScanConfig::new(dummy_url, self.schema.arrow_schema.clone())
-            .with_output_ordering(vec![sort_exprs.clone()])
+            .with_output_ordering(vec![sort_exprs.clone(); file_groups.len()])
             .with_file_groups(file_groups)
             .with_projection(projections);
 
@@ -569,7 +569,7 @@ mod tests {
                 .indent(true);
         assert_eq!(
             r#"MergeExec: [primary_keys: 1, seq_idx: 2]
-  SortPreservingMergeExec: [pk1@0 ASC, __seq__@2 ASC], fetch=1024
+  SortPreservingMergeExec: [pk1@0 ASC, __seq__@2 ASC]
     ParquetExec: file_groups={3 groups: [[mock/data/100.sst], [mock/data/101.sst], [mock/data/102.sst]]}, projection=[pk1, value, __seq__], output_orderings=[[pk1@0 ASC, __seq__@2 ASC], [pk1@0 ASC, __seq__@2 ASC], [pk1@0 ASC, __seq__@2 ASC]]
 "#,
             format!("{display_plan}")

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -51,7 +51,7 @@ use datafusion::{
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use parquet::arrow::async_reader::ParquetObjectReader;
-use tracing::debug;
+use tracing::trace;
 
 use crate::{
     compare_primitive_columns,
@@ -266,7 +266,7 @@ impl MergeStream {
             return Ok(None);
         }
 
-        debug!(pending_batch = ?self.pending_batch, "Merge batch");
+        trace!(pending_batch = ?self.pending_batch, "Merge batch");
 
         // Group rows with the same primary keys
         let mut groupby_pk_batches = Vec::new();
@@ -280,7 +280,7 @@ impl MergeStream {
             }
             groupby_pk_batches.push(batch.slice(start_idx, end_idx - start_idx));
             start_idx = end_idx;
-            debug!(end_idx = end_idx, "Group rows with the same primary keys");
+            trace!(end_idx, "Group rows with the same primary keys");
         }
 
         let rows_with_same_primary_keys = &groupby_pk_batches[0];

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -426,7 +426,7 @@ impl ParquetReader {
             })
             .collect::<Vec<_>>();
         let scan_config = FileScanConfig::new(dummy_url, self.schema.arrow_schema.clone())
-            .with_output_ordering(vec![sort_exprs.clone(); file_groups.len()])
+            .with_output_ordering(vec![sort_exprs.clone()])
             .with_file_groups(file_groups)
             .with_projection(projections);
 
@@ -443,8 +443,6 @@ impl ParquetReader {
         // when convert between arrow and parquet.
         let parquet_exec = builder.build();
         let sort_exec = SortPreservingMergeExec::new(sort_exprs, Arc::new(parquet_exec))
-            // TODO: make fetch size configurable.
-            .with_fetch(Some(1024))
             .with_round_robin_repartition(true);
 
         let merge_exec = MergeExec::new(

--- a/src/metric_engine/src/sst.rs
+++ b/src/metric_engine/src/sst.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::{
+    fmt,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, LazyLock,
@@ -46,9 +47,19 @@ static NEXT_ID: LazyLock<AtomicU64> = LazyLock::new(|| {
 
 pub type FileId = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SstFile {
     inner: Arc<Inner>,
+}
+
+impl fmt::Debug for SstFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SstFile")
+            .field("id", &self.id())
+            .field("meta", &self.meta())
+            .field("in_compaction", &self.is_compaction())
+            .finish()
+    }
 }
 
 #[derive(Debug)]

--- a/src/metric_engine/src/storage.rs
+++ b/src/metric_engine/src/storage.rs
@@ -49,15 +49,13 @@ use parquet::{
 use tokio::runtime::Runtime;
 
 use crate::{
-    compaction::{CompactionScheduler, SchedulerConfig},
+    compaction::CompactionScheduler,
+    config::{SchedulerConfig, StorageOptions, WriteOptions},
     ensure,
     manifest::{Manifest, ManifestRef},
     read::ParquetReader,
     sst::{FileMeta, SstFile, SstPathGenerator},
-    types::{
-        ObjectStoreRef, StorageOptions, StorageSchema, TimeRange, WriteOptions, WriteResult,
-        SEQ_COLUMN_NAME,
-    },
+    types::{ObjectStoreRef, StorageSchema, TimeRange, WriteResult, SEQ_COLUMN_NAME},
     Result,
 };
 

--- a/src/metric_engine/src/storage.rs
+++ b/src/metric_engine/src/storage.rs
@@ -53,7 +53,7 @@ use crate::{
     ensure,
     manifest::{Manifest, ManifestRef},
     read::ParquetReader,
-    sst::{allocate_id, FileMeta, SstPathGenerator},
+    sst::{FileMeta, SstFile, SstPathGenerator},
     types::{
         ObjectStoreRef, StorageOptions, StorageSchema, TimeRange, WriteOptions, WriteResult,
         SEQ_COLUMN_NAME,
@@ -217,7 +217,7 @@ impl CloudObjectStorage {
     }
 
     async fn write_batch(&self, batch: RecordBatch) -> Result<WriteResult> {
-        let file_id = allocate_id();
+        let file_id = SstFile::allocate_id();
         let file_path = self.sst_path_gen.generate(file_id);
         let file_path = Path::from(file_path);
         let object_store_writer = ParquetObjectWriter::new(self.store.clone(), file_path.clone());

--- a/src/metric_engine/src/types.rs
+++ b/src/metric_engine/src/types.rs
@@ -176,7 +176,7 @@ pub struct ManifestMergeOptions {
 impl Default for ManifestMergeOptions {
     fn default() -> Self {
         Self {
-            channel_size: 10,
+            channel_size: 3,
             merge_interval_seconds: 5,
             min_merge_threshold: 10,
             soft_merge_threshold: 50,

--- a/src/metric_engine/src/types.rs
+++ b/src/metric_engine/src/types.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::{
-    collections::HashMap,
     ops::{Add, Deref, Range},
     sync::Arc,
     time::Duration,
@@ -24,7 +23,6 @@ use std::{
 
 use arrow_schema::SchemaRef;
 use object_store::ObjectStore;
-use parquet::basic::{Compression, Encoding, ZstdLevel};
 use tokio::runtime::Runtime;
 
 use crate::sst::FileId;
@@ -127,76 +125,11 @@ pub struct WriteResult {
     pub size: usize,
 }
 
-#[derive(Debug)]
-pub struct ColumnOptions {
-    pub enable_dict: Option<bool>,
-    pub enable_bloom_filter: Option<bool>,
-    pub encoding: Option<Encoding>,
-    pub compression: Option<Compression>,
-}
-
-#[derive(Debug)]
-pub struct WriteOptions {
-    pub max_row_group_size: usize,
-    pub write_bacth_size: usize,
-    pub enable_sorting_columns: bool,
-    // use to set column props with default value
-    pub enable_dict: bool,
-    pub enable_bloom_filter: bool,
-    pub encoding: Encoding,
-    pub compression: Compression,
-    // use to set column props with column name
-    pub column_options: Option<HashMap<String, ColumnOptions>>,
-}
-
-impl Default for WriteOptions {
-    fn default() -> Self {
-        Self {
-            max_row_group_size: 8192,
-            write_bacth_size: 1024,
-            enable_sorting_columns: true,
-            enable_dict: false,
-            enable_bloom_filter: false,
-            encoding: Encoding::PLAIN,
-            compression: Compression::ZSTD(ZstdLevel::default()),
-            column_options: None,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct ManifestMergeOptions {
-    pub channel_size: usize,
-    pub merge_interval_seconds: usize,
-    pub min_merge_threshold: usize,
-    pub hard_merge_threshold: usize,
-    pub soft_merge_threshold: usize,
-}
-
-impl Default for ManifestMergeOptions {
-    fn default() -> Self {
-        Self {
-            channel_size: 3,
-            merge_interval_seconds: 5,
-            min_merge_threshold: 10,
-            soft_merge_threshold: 50,
-            hard_merge_threshold: 90,
-        }
-    }
-}
-
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UpdateMode {
     #[default]
     Overwrite,
     Append,
-}
-
-#[derive(Debug, Default)]
-pub struct StorageOptions {
-    pub write_opts: WriteOptions,
-    pub manifest_merge_opts: ManifestMergeOptions,
-    pub update_mode: UpdateMode,
 }
 
 #[derive(Debug, Clone)]

--- a/src/metric_engine/src/types.rs
+++ b/src/metric_engine/src/types.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::{
+    fmt,
     ops::{Add, Deref, Range},
     sync::Arc,
     time::Duration,
@@ -76,8 +77,14 @@ impl Timestamp {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TimeRange(Range<Timestamp>);
+
+impl fmt::Debug for TimeRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}, {})", self.0.start.0, self.0.end.0)
+    }
+}
 
 impl From<Range<Timestamp>> for TimeRange {
     fn from(value: Range<Timestamp>) -> Self {

--- a/src/metric_engine/src/types.rs
+++ b/src/metric_engine/src/types.rs
@@ -26,7 +26,7 @@ use arrow_schema::SchemaRef;
 use object_store::ObjectStore;
 use tokio::runtime::Runtime;
 
-use crate::sst::FileId;
+use crate::{config::UpdateMode, sst::FileId};
 
 // Seq column is a builtin column, and it will be appended to the end of
 // user-defined schema.
@@ -130,13 +130,6 @@ pub struct WriteResult {
     pub id: FileId,
     pub seq: u64,
     pub size: usize,
-}
-
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum UpdateMode {
-    #[default]
-    Overwrite,
-    Append,
 }
 
 #[derive(Debug, Clone)]

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -43,4 +43,4 @@ serde = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true , features = ["local-time"]}
+tracing-subscriber = { workspace = true, features = ["local-time"] }

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -43,4 +43,4 @@ serde = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true , features = ["local-time"]}

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -43,4 +43,4 @@ serde = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["local-time"] }
+tracing-subscriber = { workspace = true, features = ["local-time", "env-filter"] }

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -66,14 +66,8 @@ pub struct MetricEngineConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ThreadConfig {
-    #[serde(default = "default_thread_num")]
     pub manifest_thread_num: usize,
-    #[serde(default = "default_thread_num")]
     pub sst_thread_num: usize,
-}
-
-fn default_thread_num() -> usize {
-    2
 }
 
 impl Default for ThreadConfig {

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -41,6 +41,7 @@ impl Default for Config {
 pub struct TestConfig {
     pub enable_write: bool,
     pub write_worker_num: usize,
+    pub segment_duration: ReadableDuration,
     pub write_interval: ReadableDuration,
 }
 
@@ -49,6 +50,7 @@ impl Default for TestConfig {
         Self {
             enable_write: true,
             write_worker_num: 1,
+            segment_duration: ReadableDuration::hours(12),
             write_interval: ReadableDuration::millis(500),
         }
     }

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -19,7 +19,7 @@ use common::ReadableDuration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub port: u16,
     pub test: TestConfig, // for test
@@ -37,7 +37,7 @@ impl Default for Config {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TestConfig {
     pub enable_write: bool,
     pub write_worker_num: usize,
@@ -55,7 +55,7 @@ impl Default for TestConfig {
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MetricEngineConfig {
     pub manifest: ManifestConfig,
     pub sst: SstConfig,
@@ -63,7 +63,7 @@ pub struct MetricEngineConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ManifestConfig {
     pub background_thread_num: usize,
 }
@@ -77,7 +77,7 @@ impl Default for ManifestConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SstConfig {
     pub background_thread_num: usize,
 }
@@ -91,7 +91,7 @@ impl Default for SstConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[allow(clippy::large_enum_variant)]
 pub enum StorageConfig {
     Local(LocalStorageConfig),
@@ -118,6 +118,7 @@ impl Default for LocalStorageConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct S3LikeStorageConfig {
     pub region: String,
     pub key_id: String,
@@ -134,6 +135,7 @@ pub struct S3LikeStorageConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct HttpOptions {
     pub pool_max_idle_per_host: usize,
     pub timeout: ReadableDuration,

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -41,6 +41,7 @@ impl Default for Config {
 pub struct TestConfig {
     pub enable_write: bool,
     pub write_worker_num: usize,
+    pub write_interval: ReadableDuration,
 }
 
 impl Default for TestConfig {
@@ -48,6 +49,7 @@ impl Default for TestConfig {
         Self {
             enable_write: true,
             write_worker_num: 1,
+            write_interval: ReadableDuration::millis(500),
         }
     }
 }

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -18,7 +18,7 @@
 use common::ReadableDuration;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub port: u16,
@@ -56,51 +56,51 @@ impl Default for TestConfig {
     }
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MetricEngineConfig {
-    pub manifest: ManifestConfig,
-    pub sst: SstConfig,
+    pub threads: ThreadConfig,
     pub storage: StorageConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct ManifestConfig {
-    pub background_thread_num: usize,
+pub struct ThreadConfig {
+    #[serde(default = "default_thread_num")]
+    pub manifest_thread_num: usize,
+    #[serde(default = "default_thread_num")]
+    pub sst_thread_num: usize,
 }
 
-impl Default for ManifestConfig {
+fn default_thread_num() -> usize {
+    2
+}
+
+impl Default for ThreadConfig {
     fn default() -> Self {
         Self {
-            background_thread_num: 2,
+            manifest_thread_num: 2,
+            sst_thread_num: 2,
         }
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct SstConfig {
-    pub background_thread_num: usize,
-}
-
-impl Default for SstConfig {
-    fn default() -> Self {
-        Self {
-            background_thread_num: 2,
-        }
-    }
+pub struct StorageConfig {
+    pub object_store: ObjectStorageConfig,
+    pub time_merge_storage: metric_engine::config::StorageConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", deny_unknown_fields)]
 #[allow(clippy::large_enum_variant)]
-pub enum StorageConfig {
+pub enum ObjectStorageConfig {
     Local(LocalStorageConfig),
     S3Like(S3LikeStorageConfig),
 }
 
-impl Default for StorageConfig {
+impl Default for ObjectStorageConfig {
     fn default() -> Self {
         Self::Local(LocalStorageConfig::default())
     }

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct Config {
     pub port: u16,
-    pub write_worker_num: usize, // for test
+    pub test: TestConfig, // for test
     pub metric_engine: MetricEngineConfig,
 }
 
@@ -30,8 +30,24 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             port: 5000,
-            write_worker_num: 4,
+            test: TestConfig::default(),
             metric_engine: MetricEngineConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TestConfig {
+    pub enable_write: bool,
+    pub write_worker_num: usize,
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            enable_write: true,
+            write_worker_num: 1,
         }
     }
 }

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -176,6 +176,7 @@ fn bench_write(rt: RuntimeRef, workers: usize, storage: TimeMergeStorageRef) {
                 {
                     error!("write failed, err:{}", e);
                 }
+                tokio::time::sleep(Duration::from_millis(1000)).await;
             }
         });
     }

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -31,10 +31,11 @@ use arrow::{
 use clap::Parser;
 use config::{Config, StorageConfig};
 use metric_engine::{
+    config::StorageOptions,
     storage::{
         CloudObjectStorage, CompactRequest, StorageRuntimes, TimeMergeStorageRef, WriteRequest,
     },
-    types::{RuntimeRef, StorageOptions},
+    types::RuntimeRef,
 };
 use object_store::local::LocalFileSystem;
 use tracing::{error, info};
@@ -65,8 +66,12 @@ struct AppState {
 }
 
 pub fn main() {
-    // install global collector configured based on RUST_LOG env var.
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(false)
+        .with_timer(tracing_subscriber::fmt::time::LocalTime::rfc_3339())
+        .init();
 
     let args = Args::parse();
     let config_body = fs::read_to_string(args.config).expect("read config file failed");

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -39,6 +39,7 @@ use metric_engine::{
 };
 use object_store::local::LocalFileSystem;
 use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about)]
@@ -70,6 +71,7 @@ pub fn main() {
         .with_file(true)
         .with_line_number(true)
         .with_target(false)
+        .with_env_filter(EnvFilter::from_default_env())
         .with_timer(tracing_subscriber::fmt::time::LocalTime::rfc_3339())
         .init();
 

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -97,6 +97,7 @@ pub fn main() {
     };
     let write_worker_num = config.test.write_worker_num;
     let write_interval = config.test.write_interval.0;
+    let segment_duration = config.test.segment_duration.0;
     let enable_write = config.test.enable_write;
     let write_rt = build_multi_runtime("write", write_worker_num);
     let _ = rt.block_on(async move {
@@ -104,7 +105,7 @@ pub fn main() {
         let storage = Arc::new(
             CloudObjectStorage::try_new(
                 storage_config.data_dir,
-                Duration::from_mins(10),
+                segment_duration,
                 store,
                 build_schema(),
                 3,

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -88,7 +88,8 @@ pub fn main() {
         StorageConfig::Local(v) => v,
         StorageConfig::S3Like(_) => panic!("S3 not support yet"),
     };
-    let write_worker_num = config.write_worker_num;
+    let write_worker_num = config.test.write_worker_num;
+    let enable_write = config.test.enable_write;
     let write_rt = build_multi_runtime("write", write_worker_num);
     let _ = rt.block_on(async move {
         let store = Arc::new(LocalFileSystem::new());
@@ -106,7 +107,9 @@ pub fn main() {
             .unwrap(),
         );
 
-        bench_write(write_rt.clone(), write_worker_num, storage.clone());
+        if enable_write {
+            bench_write(write_rt.clone(), write_worker_num, storage.clone());
+        }
 
         let app_state = Data::new(AppState { storage });
         info!(port, "Start HoraeDB http server...");


### PR DESCRIPTION
## Rationale
Fix bugs found in local write bench.

## Detailed Changes
- When manifest starts up, the delta num may overflow since it's initialized to 0.
- When manifest merge_update, since the deltas is unsorted, so we may first delete a non-existing file.

## Test Plan
CI