### PR TITLE
feat: skip add sequence column when compact 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 
 [workspace.package]
 version = "2.2.0-alpha"
-authors = ["HoraeDB Authors"]
+authors = ["Apache HoraeDB(incubating) <dev@horaedb.apache.org>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/apache/horaedb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ version = "2.2.0-alpha"
 authors = ["HoraeDB Authors"]
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/apache/horaedb"
+homepage = "https://horaedb.apache.org/"
+description = "A high-performance, distributed, cloud native time-series database."
 
 [workspace]
 resolver = "2"

--- a/src/benchmarks/Cargo.toml
+++ b/src/benchmarks/Cargo.toml
@@ -17,18 +17,13 @@
 
 [package]
 name = "benchmarks"
-
-[package.license]
-workspace = true
-
-[package.version]
-workspace = true
-
-[package.authors]
-workspace = true
-
-[package.edition]
-workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 
 [dependencies]
 bytes = { workspace = true }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -17,18 +17,13 @@
 
 [package]
 name = "common"
-
-[package.license]
-workspace = true
-
-[package.version]
-workspace = true
-
-[package.authors]
-workspace = true
-
-[package.edition]
-workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/src/metric_engine/Cargo.toml
+++ b/src/metric_engine/Cargo.toml
@@ -17,18 +17,14 @@
 
 [package]
 name = "metric_engine"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 
-[package.license]
-workspace = true
-
-[package.version]
-workspace = true
-
-[package.authors]
-workspace = true
-
-[package.edition]
-workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/src/metric_engine/Cargo.toml
+++ b/src/metric_engine/Cargo.toml
@@ -25,7 +25,6 @@ repository.workspace = true
 homepage.workspace = true
 description.workspace = true
 
-
 [dependencies]
 anyhow = { workspace = true }
 arrow = { workspace = true }

--- a/src/metric_engine/src/read.rs
+++ b/src/metric_engine/src/read.rs
@@ -217,6 +217,11 @@ impl MergeStream {
         keep_sequence: bool,
     ) -> Self {
         let arrow_schema = if keep_sequence {
+            let schema = stream.schema();
+            let found_seq = schema.fields().iter().any(|f| f.name() == SEQ_COLUMN_NAME);
+            assert!(found_seq, "Sequence column not found");
+            schema
+        } else {
             let fields = stream
                 .schema()
                 .fields()
@@ -233,8 +238,6 @@ impl MergeStream {
                 fields,
                 stream.schema().metadata.clone(),
             ))
-        } else {
-            stream.schema()
         };
         Self {
             stream,

--- a/src/metric_engine/src/storage.rs
+++ b/src/metric_engine/src/storage.rs
@@ -380,6 +380,7 @@ impl TimeMergeStorage for CloudObjectStorage {
                 ssts,
                 req.projections.clone(),
                 req.predicate.clone(),
+                false, // keep_sequence
             )?;
 
             plan_for_all_segments.push(plan);

--- a/src/pb_types/Cargo.toml
+++ b/src/pb_types/Cargo.toml
@@ -17,18 +17,13 @@
 
 [package]
 name = "pb_types"
-
-[package.license]
-workspace = true
-
-[package.version]
-workspace = true
-
-[package.authors]
-workspace = true
-
-[package.edition]
-workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 
 [dependencies]
 prost = { workspace = true }

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -17,18 +17,13 @@
 
 [package]
 name = "server"
-
-[package.license]
-workspace = true
-
-[package.version]
-workspace = true
-
-[package.authors]
-workspace = true
-
-[package.edition]
-workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 
 [dependencies]
 actix-web = "4"


### PR DESCRIPTION
## Rationale


## Detailed Changes
- Refactor package metadata
- ParquetReader add `keep_sequence` args, and set it to `true`for compaction, `false` for query.

## Test Plan

CI
```
 cargo publish --dry-run --registry crates-io
```
This commands run successfully.